### PR TITLE
Query placeholders

### DIFF
--- a/src/createChannel.ts
+++ b/src/createChannel.ts
@@ -1,21 +1,27 @@
-import { reactive, ref, toRefs } from "vue";
-import { Query, QueryAction, QueryOptions } from "./types";
+import { computed, reactive, ref, toRefs } from "vue";
+import { Query, QueryAction, QueryOptions } from "./types/query";
 import { createSequence } from "./createSequence";
 
-export type Channel<TAction extends QueryAction = any> = {
-  subscribe: (options?: QueryOptions<TAction>) => Query<TAction>,
+export type Channel<
+  TAction extends QueryAction = any,
+> = {
+  subscribe: <TPlaceholder extends unknown>(options?: QueryOptions<TAction, TPlaceholder>) => Query<TAction, TPlaceholder>,
   active: boolean,
 }
 
-export function createChannel<TAction extends QueryAction>(action: TAction, parameters: Parameters<TAction>): Channel<TAction> {
-  const response = ref<Query<TAction>['response']>()
-  const error = ref<Query<TAction>['error']>()
-  const errored = ref<Query<TAction>['errored']>(false)
-  const executing = ref<Query<TAction>['executing']>(false)
-  const executed = ref<Query<TAction>['executed']>(false)
+export function createChannel<
+  TAction extends QueryAction,
+>(action: TAction, parameters: Parameters<TAction>): Channel<TAction> {
+  type ChannelQuery = Query<TAction, unknown>
+
+  const response = ref<ChannelQuery['response']>()
+  const error = ref<ChannelQuery['error']>()
+  const errored = ref<ChannelQuery['errored']>(false)
+  const executing = ref<ChannelQuery['executing']>(false)
+  const executed = ref<ChannelQuery['executed']>(false)
   const { promise, resolve } = Promise.withResolvers<unknown>()
 
-  const subscriptions = new Map<number, QueryOptions<TAction>>()
+  const subscriptions = new Map<number, QueryOptions<TAction, unknown>>()
   const nextId = createSequence()
 
   async function execute(): Promise<void> {
@@ -58,10 +64,10 @@ export function createChannel<TAction extends QueryAction>(action: TAction, para
     resolve(value)
   }
 
-  function addSubscription(options?: QueryOptions<TAction>): () => void {
+  function addSubscription(options?: QueryOptions<TAction, unknown>): () => void {
     const id = nextId()
 
-    subscriptions.set(id, options ?? {})
+    subscriptions.set(id, options ?? {})  
 
     if(!executed.value && !executing.value) {
       execute()
@@ -72,11 +78,13 @@ export function createChannel<TAction extends QueryAction>(action: TAction, para
     }
   }
 
-  function subscribe(options?: QueryOptions<TAction>): Query<TAction> {
+  function subscribe<
+    TPlaceholder extends unknown
+  >(options?: QueryOptions<TAction, TPlaceholder>): Query<TAction, TPlaceholder> {
     const dispose = addSubscription(options)
 
-    const query: Omit<Query<TAction>, 'then' | typeof Symbol.dispose> = reactive({
-      response,
+    const query: Omit<Query<TAction, TPlaceholder>, 'then' | typeof Symbol.dispose> = reactive({
+      response: computed(() => response.value ?? options?.placeholder),
       error,
       errored,
       executing,
@@ -84,7 +92,7 @@ export function createChannel<TAction extends QueryAction>(action: TAction, para
       dispose,
     })
 
-    const then: Query<TAction>['then'] = (onFulfilled: any, onRejected: any) => {
+    const then: Query<TAction, TPlaceholder>['then'] = (onFulfilled: any, onRejected: any) => {
       return promise.then((value) => {
         if(value instanceof Error) {
           throw value

--- a/src/createClient.spec.ts
+++ b/src/createClient.spec.ts
@@ -113,6 +113,20 @@ describe('query', () => {
 
     expect(onError).toHaveBeenCalledOnce()
   })
+
+  test('placeholder', async () => {
+    const placeholder = Symbol('placeholder')
+    const response = Symbol('response')
+    const { query } = createClient()
+
+    const value = query(() => response, [], { placeholder })
+
+    expect(value.response).toBe(placeholder)
+
+    await nextTick()
+
+    expect(value.response).toBe(response)
+  })
 })
 
 describe('useQuery', () => {

--- a/src/createClient.ts
+++ b/src/createClient.ts
@@ -27,9 +27,9 @@ export function createClient(options?: ClientOptions): QueryClient {
   }
 
   function subscribe<
-    TAction extends QueryAction,
-    TPlaceholder extends unknown
-  >(action: TAction, parameters: Parameters<TAction>, options?: QueryOptions<TAction, TPlaceholder>): Query<TAction, TPlaceholder> {
+    const TAction extends QueryAction,
+    const TOptions extends QueryOptions<TAction>
+  >(action: TAction, parameters: Parameters<TAction>, options?: TOptions): Query<TAction, TOptions> {
     const channel = getChannel(action, parameters)
 
     return channel.subscribe(options)
@@ -74,7 +74,10 @@ export function createClient(options?: ClientOptions): QueryClient {
     return query
   }
 
-  const defineQuery: DefineQuery = <TAction extends QueryAction, TOptions extends unknown>(action: TAction) => {
+  const defineQuery: DefineQuery = <
+    TAction extends QueryAction,
+    TOptions extends QueryOptions<TAction>
+  >(action: TAction) => {
     const definedQuery: DefinedQueryFunction<TAction, TOptions> = (args, options) => {
       return query(action, args, options)
     }

--- a/src/createClient.ts
+++ b/src/createClient.ts
@@ -1,44 +1,12 @@
 import { computed, onScopeDispose, toRefs, toValue, watch } from "vue";
-import { ClientOptions, Query, QueryAction, QueryActionArgs, QueryOptions } from "./types";
+import { Query, QueryAction, QueryOptions } from "./types/query";
 import isEqual from 'lodash.isequal'
 import { isDefined } from "./utilities";
 import { createGetQueryKey } from "./createQueryKey";
 import { Channel, createChannel } from "./createChannel";
 import { QueryKey } from "./createQueryKey";
-
-export type QueryClient = {
-  query: QueryFunction,
-  useQuery: QueryComposition,
-  defineQuery: DefineQuery,
-}
-
-export type QueryFunction = <
-  TAction extends QueryAction
->(action: TAction, args: Parameters<TAction>, options?: QueryOptions<TAction>) => Query<TAction>
-
-export type DefinedQueryFunction<
-  TAction extends QueryAction
-> = (args: Parameters<TAction>, options?: QueryOptions<TAction>) => Query<TAction>
-
-export type QueryComposition = <
-  const TAction extends QueryAction,
-  const Args extends QueryActionArgs<TAction>
->(action: TAction, args: Args, options?: QueryOptions<TAction>) => Query<TAction>
-
-export type DefinedQueryComposition<
-  TAction extends QueryAction
-> = (args: QueryActionArgs<TAction>, options?: QueryOptions<TAction>) => Query<TAction>
-
-export type DefineQuery = <
-  const TAction extends QueryAction
->(action: TAction) => DefinedQuery<TAction>
-
-export type DefinedQuery<
-  TAction extends QueryAction
-> = {
-  query: DefinedQueryFunction<TAction>
-  useQuery: DefinedQueryComposition<TAction>
-}
+import { ClientOptions } from "./types/clientOptions";
+import { DefinedQueryComposition, DefinedQueryFunction, DefineQuery, QueryClient, QueryComposition, QueryFunction } from "./types/client";
 
 const noop = () => undefined
 
@@ -47,7 +15,7 @@ export function createClient(options?: ClientOptions): QueryClient {
   const channels = new Map<QueryKey, Channel>()
 
   function getChannel<
-    TAction extends QueryAction
+    TAction extends QueryAction,
   >(action: TAction, parameters: Parameters<TAction>): Channel<TAction> {
     const queryKey = getQueryKey(action, parameters)
 
@@ -59,8 +27,9 @@ export function createClient(options?: ClientOptions): QueryClient {
   }
 
   function subscribe<
-    TAction extends QueryAction
-  >(action: TAction, parameters: Parameters<TAction>, options?: QueryOptions<TAction>): Query<TAction> {
+    TAction extends QueryAction,
+    TPlaceholder extends unknown
+  >(action: TAction, parameters: Parameters<TAction>, options?: QueryOptions<TAction, TPlaceholder>): Query<TAction, TPlaceholder> {
     const channel = getChannel(action, parameters)
 
     return channel.subscribe(options)
@@ -71,27 +40,27 @@ export function createClient(options?: ClientOptions): QueryClient {
   }
 
   const useQuery: QueryComposition = (action, parameters, options) => {
-    const value = query(noop, [])
+    const query = subscribe(noop, [], options)
 
     watch(() => toValue(parameters), (parameters, previousParameters) => {
       if(isDefined(previousParameters) && isEqual(previousParameters, parameters)) {
         return
       }
 
-      value.dispose()
+      query.dispose()
 
       if(parameters === null) {
-        const newValue = query(noop, [])
+        const newValue = subscribe(noop, [], options)
 
-        Object.assign(value, toRefs(newValue))
+        Object.assign(query, toRefs(newValue))
 
         return
       }
 
-      const newValue = query(action, parameters, options)
-      const previousResponse = value.response
+      const newValue = subscribe(action, parameters, options)
+      const previousResponse = query.response
 
-      Object.assign(value, {
+      Object.assign(query, {
         ...toRefs(newValue),
         response: computed(() => {
           return newValue.response ?? previousResponse
@@ -100,17 +69,17 @@ export function createClient(options?: ClientOptions): QueryClient {
           
     }, { deep: true, immediate: true })
 
-    onScopeDispose(() => value.dispose())
+    onScopeDispose(() => query.dispose())
 
-    return value
+    return query
   }
 
-  const defineQuery: DefineQuery = <TAction extends QueryAction>(action: TAction) => {
-    const definedQuery: DefinedQueryFunction<TAction> = (args, options) => {
+  const defineQuery: DefineQuery = <TAction extends QueryAction, TOptions extends unknown>(action: TAction) => {
+    const definedQuery: DefinedQueryFunction<TAction, TOptions> = (args, options) => {
       return query(action, args, options)
     }
 
-    const definedUseQuery: DefinedQueryComposition<TAction> = (args, options) => {
+    const definedUseQuery: DefinedQueryComposition<TAction, TOptions> = (args, options) => {
       return useQuery(action, args, options)
     }
 

--- a/src/types/client.ts
+++ b/src/types/client.ts
@@ -10,35 +10,35 @@ export type QueryClient = {
 }
 
 export type QueryFunction = <
-  TAction extends QueryAction,
-  TPlaceholder extends unknown
->(action: TAction, args: Parameters<TAction>, options?: QueryOptions<TAction, TPlaceholder>) => Query<TAction, TPlaceholder>
+  const TAction extends QueryAction,
+  const TOptions extends QueryOptions<TAction>
+>(action: TAction, args: Parameters<TAction>, options?: TOptions) => Query<TAction, TOptions>
 
 export type DefinedQueryFunction<
   TAction extends QueryAction,
-  TPlaceholder extends unknown
-> = (args: Parameters<TAction>, options?: QueryOptions<TAction, TPlaceholder>) => Query<TAction, TPlaceholder>
+  TOptions extends QueryOptions<TAction>
+> = (args: Parameters<TAction>, options?: TOptions) => Query<TAction, TOptions>
 
 export type QueryComposition = <
   const TAction extends QueryAction,
   const Args extends QueryActionArgs<TAction>,
-  const TPlaceholder extends unknown
->(action: TAction, args: Args, options?: QueryOptions<TAction, TPlaceholder>) => Query<TAction, TPlaceholder>
+  const TOptions extends QueryOptions<TAction>
+>(action: TAction, args: Args, options?: TOptions) => Query<TAction, TOptions>
 
 export type DefinedQueryComposition<
   TAction extends QueryAction,
-  TPlaceholder extends unknown
-> = (args: QueryActionArgs<TAction>, options?: QueryOptions<TAction, TPlaceholder>) => Query<TAction, TPlaceholder>
+  TOptions extends QueryOptions<TAction>
+> = (args: QueryActionArgs<TAction>, options?: TOptions) => Query<TAction, TOptions>
 
 export type DefineQuery = <
   const TAction extends QueryAction,
-  const TPlaceholder extends unknown
->(action: TAction) => DefinedQuery<TAction, TPlaceholder>
+  const TOptions extends QueryOptions<TAction>
+>(action: TAction) => DefinedQuery<TAction, TOptions>
 
 export type DefinedQuery<
   TAction extends QueryAction,
-  TPlaceholder extends unknown
+  TOptions extends QueryOptions<TAction>
 > = {
-  query: DefinedQueryFunction<TAction, TPlaceholder>
-  useQuery: DefinedQueryComposition<TAction, TPlaceholder>
+  query: DefinedQueryFunction<TAction, TOptions>
+  useQuery: DefinedQueryComposition<TAction, TOptions>
 }

--- a/src/types/client.ts
+++ b/src/types/client.ts
@@ -1,0 +1,44 @@
+import { QueryActionArgs } from "./query"
+import { Query } from "./query"
+import { QueryOptions } from "./query"
+import { QueryAction } from "./query"
+
+export type QueryClient = {
+  query: QueryFunction,
+  useQuery: QueryComposition,
+  defineQuery: DefineQuery,
+}
+
+export type QueryFunction = <
+  TAction extends QueryAction,
+  TPlaceholder extends unknown
+>(action: TAction, args: Parameters<TAction>, options?: QueryOptions<TAction, TPlaceholder>) => Query<TAction, TPlaceholder>
+
+export type DefinedQueryFunction<
+  TAction extends QueryAction,
+  TPlaceholder extends unknown
+> = (args: Parameters<TAction>, options?: QueryOptions<TAction, TPlaceholder>) => Query<TAction, TPlaceholder>
+
+export type QueryComposition = <
+  const TAction extends QueryAction,
+  const Args extends QueryActionArgs<TAction>,
+  const TPlaceholder extends unknown
+>(action: TAction, args: Args, options?: QueryOptions<TAction, TPlaceholder>) => Query<TAction, TPlaceholder>
+
+export type DefinedQueryComposition<
+  TAction extends QueryAction,
+  TPlaceholder extends unknown
+> = (args: QueryActionArgs<TAction>, options?: QueryOptions<TAction, TPlaceholder>) => Query<TAction, TPlaceholder>
+
+export type DefineQuery = <
+  const TAction extends QueryAction,
+  const TPlaceholder extends unknown
+>(action: TAction) => DefinedQuery<TAction, TPlaceholder>
+
+export type DefinedQuery<
+  TAction extends QueryAction,
+  TPlaceholder extends unknown
+> = {
+  query: DefinedQueryFunction<TAction, TPlaceholder>
+  useQuery: DefinedQueryComposition<TAction, TPlaceholder>
+}

--- a/src/types/clientOptions.ts
+++ b/src/types/clientOptions.ts
@@ -1,0 +1,4 @@
+export type ClientOptions = {
+  pauseActionsInBackground: boolean
+}
+

--- a/src/types/getters.ts
+++ b/src/types/getters.ts
@@ -1,0 +1,2 @@
+export type MaybeGetter<T> = T | Getter<T>
+export type Getter<T> = () => T

--- a/src/types/query.ts
+++ b/src/types/query.ts
@@ -1,21 +1,25 @@
-type MaybeGetter<T> = T | Getter<T>
-type Getter<T> = () => T
-
-export type ClientOptions = {
-  pauseActionsInBackground: boolean
-}
+import { Getter, MaybeGetter } from "./getters";
 
 export type QueryAction = (...args: any[]) => any
 
 export type QueryActionArgs<TAction extends QueryAction> = MaybeGetter<Parameters<TAction>> | Getter<Parameters<TAction> | null> | Getter<null>
 
-export type QueryOptions<TAction extends QueryAction> = {
+export type QueryOptions<
+  TAction extends QueryAction,
+  TPlaceholder extends unknown
+> = {
+  placeholder?: TPlaceholder,
   onSuccess?: (value: Awaited<ReturnType<TAction>>) => void,
   onError?: (error: unknown) => void,
 }
 
-export type Query<TAction extends QueryAction> = PromiseLike<AwaitedQuery<TAction>> & {
-  response: Awaited<ReturnType<TAction>> | undefined,
+type QueryPlaceholder<TPlaceholder extends unknown> = unknown extends TPlaceholder ? undefined : TPlaceholder
+
+export type Query<
+  TAction extends QueryAction,
+  TPlaceholder extends unknown
+> = PromiseLike<AwaitedQuery<TAction>> & {
+  response: Awaited<ReturnType<TAction>> | QueryPlaceholder<TPlaceholder>,
   error: unknown,
   errored: boolean,
   executed: boolean,
@@ -24,7 +28,9 @@ export type Query<TAction extends QueryAction> = PromiseLike<AwaitedQuery<TActio
   [Symbol.dispose](): void;
 }
 
-export type AwaitedQuery<TAction extends QueryAction> = {
+export type AwaitedQuery<
+  TAction extends QueryAction,
+> = {
   response: Awaited<ReturnType<TAction>>,
   error: unknown,
   errored: boolean,

--- a/src/types/query.ts
+++ b/src/types/query.ts
@@ -12,15 +12,11 @@ export type QueryOptions<
   onError?: (error: unknown) => void,
 }
 
-export type QueryPlaceholder<
-  TPlaceholder extends unknown
-> = unknown extends TPlaceholder ? undefined : TPlaceholder
-
 export type Query<
   TAction extends QueryAction,
   TOptions extends QueryOptions<TAction>
 > = PromiseLike<AwaitedQuery<TAction>> & {
-  response: Awaited<ReturnType<TAction>> | QueryPlaceholder<TOptions['placeholder']>,
+  response: Awaited<ReturnType<TAction>> | TOptions['placeholder'],
   error: unknown,
   errored: boolean,
   executed: boolean,

--- a/src/types/query.ts
+++ b/src/types/query.ts
@@ -6,20 +6,21 @@ export type QueryActionArgs<TAction extends QueryAction> = MaybeGetter<Parameter
 
 export type QueryOptions<
   TAction extends QueryAction,
-  TPlaceholder extends unknown
 > = {
-  placeholder?: TPlaceholder,
+  placeholder?: any,
   onSuccess?: (value: Awaited<ReturnType<TAction>>) => void,
   onError?: (error: unknown) => void,
 }
 
-type QueryPlaceholder<TPlaceholder extends unknown> = unknown extends TPlaceholder ? undefined : TPlaceholder
+export type QueryPlaceholder<
+  TPlaceholder extends unknown
+> = unknown extends TPlaceholder ? undefined : TPlaceholder
 
 export type Query<
   TAction extends QueryAction,
-  TPlaceholder extends unknown
+  TOptions extends QueryOptions<TAction>
 > = PromiseLike<AwaitedQuery<TAction>> & {
-  response: Awaited<ReturnType<TAction>> | QueryPlaceholder<TPlaceholder>,
+  response: Awaited<ReturnType<TAction>> | QueryPlaceholder<TOptions['placeholder']>,
   error: unknown,
   errored: boolean,
   executed: boolean,


### PR DESCRIPTION
# Description
Adds an optional `placeholder` property to `QueryOptions`. When provided the response will be `Awaited<ReturnType<TAction>> | TOptions['placeholder']` rather than `Awaited<ReturnType<TAction>> | undefined`

```ts
const value = query(() => [1, 2, 3], [], {
  placeholder: [] as number[]
})

value.response
//         ?^ string[]
```

Note: 
A common use case will be setting the placeholder to `[]` but currently that evaluates to `readonly []`. Users will want an action that returns an `string[]` to have its response be `string[]` when the placeholder `[]` is used rather than `string[] | readonly []` as it is currently. This is easily accounted for by making the placeholder `[] as string[]`. But that might not be intuitive to users. Curious if we could make the type inference there better. But for now this its pretty good. 