### PR TITLE
Reject promise no matter what value is thrown

### DIFF
--- a/src/createChannel.ts
+++ b/src/createChannel.ts
@@ -1,6 +1,7 @@
 import { computed, reactive, ref, toRefs } from "vue";
 import { Query, QueryAction, QueryOptions } from "./types/query";
 import { createSequence } from "./createSequence";
+import { QueryError } from "./queryError";
 
 export type Channel<
   TAction extends QueryAction = QueryAction,
@@ -60,8 +61,7 @@ export function createChannel<
       onError?.(value)
     }
 
-    // wrap this somehow so we can rethrow it later
-    resolve(value)
+    resolve(new QueryError(value))
   }
 
   function addSubscription(options?: QueryOptions<TAction>): () => void {
@@ -94,8 +94,8 @@ export function createChannel<
 
     const then: Query<TAction, TOptions>['then'] = (onFulfilled: any, onRejected: any) => {
       return promise.then((value) => {
-        if(value instanceof Error) {
-          throw value
+        if(value instanceof QueryError) {
+          throw value.original
         }
 
         return Object.assign(query, {

--- a/src/createClient.spec.ts
+++ b/src/createClient.spec.ts
@@ -21,7 +21,7 @@ function testInEffectScope(name: string, fn: () => Promise<void>) {
 }
 
 describe('query', () => {
-  testInEffectScope('multiple queries with the same action only executes the action once', async () => {
+  test('multiple queries with the same action only executes the action once', async () => {
     const action = vi.fn()
     const { query } = createClient()
 
@@ -64,6 +64,24 @@ describe('query', () => {
     expect(value.response).toBe(response)
   })
 
+  test.each([
+    [new Error('test')],
+    ['test'],
+    [1],
+    [true],
+    [false],
+    [null],
+    [undefined],
+  ])('error is set after action throws: %s', async (error) => {
+    const action = vi.fn(() => { throw error })
+    const { query } = createClient()
+    const value = query(action, [])
+
+    await flushPromises()
+
+    expect(value.error).toBe(error)
+  })
+
   test('awaiting a query returns the response', async () => {
     const response = Symbol('response')
     const action = vi.fn(async () => {
@@ -82,12 +100,20 @@ describe('query', () => {
     expect(value.response).toBe(response)
   })
 
-  test('awaiting a query throws an error if the action throws an error', async () => {
-    const action = vi.fn(() => { throw new Error('test') })
+  test.each([
+    [new Error('test')],
+    ['test'],
+    [1],
+    [true],
+    [false],
+    [null],
+    [undefined],
+  ])('awaiting a query throws an error if the action throws: %s', async (error) => {
+    const action = vi.fn(() => { throw error })
     const { query } = createClient()
     const value = query(action, [])
 
-    await expect(value).rejects.toThrow('test')
+    await expect(value).rejects.toThrow(error)
   })
 
   test('onSuccess', async () => {

--- a/src/createClient.spec.ts
+++ b/src/createClient.spec.ts
@@ -113,7 +113,7 @@ describe('query', () => {
     const { query } = createClient()
     const value = query(action, [])
 
-    await expect(value).rejects.toThrow(error)
+    await expect(value).rejects.toBe(error)
   })
 
   test('onSuccess', async () => {

--- a/src/queryError.ts
+++ b/src/queryError.ts
@@ -1,0 +1,6 @@
+export class QueryError extends Error {
+  constructor(public original: unknown) {
+    super()
+  }
+}
+


### PR DESCRIPTION
# Description
Wraps errors in a special `QueryError` class so we can accurately identify if the resolved promise was resolved because the query action threw a value. 