### PR TITLE
Add intervals

### DIFF
--- a/src/createChannel.spec.ts
+++ b/src/createChannel.spec.ts
@@ -17,7 +17,7 @@ test('subscribing to new channel, always executes the action', async () => {
 
   const query = channel.subscribe()
 
-  await vi.runAllTimersAsync()
+  await vi.runOnlyPendingTimersAsync()
 
   expect(query.response).toBe(response)
   expect(query.error).toBeUndefined()
@@ -36,7 +36,7 @@ test('additional subscription to existing channel, does not execute the action',
   // initial subscription
   channel.subscribe()
 
-  await vi.runAllTimersAsync()
+  await vi.runOnlyPendingTimersAsync()
   
   expect(action).toHaveBeenCalledOnce()
 
@@ -44,7 +44,7 @@ test('additional subscription to existing channel, does not execute the action',
     channel.subscribe()
   }
 
-  await vi.runAllTimersAsync()
+  await vi.runOnlyPendingTimersAsync()
 
   expect(action).toHaveBeenCalledOnce()
 })
@@ -58,7 +58,7 @@ describe('when action executes successfully', () => {
 
     const query = channel.subscribe()
 
-    await vi.runAllTimersAsync()
+    await vi.runOnlyPendingTimersAsync()
 
     expect(query.response).toBe(response)
     expect(query.error).toBeUndefined()
@@ -79,7 +79,7 @@ describe('when action executes successfully', () => {
   
     channel.subscribe({ onSuccess, onError })
   
-    await vi.runAllTimersAsync()
+    await vi.runOnlyPendingTimersAsync()
     
     expect(onSuccess).toHaveBeenCalledOnce()
     expect(onError).not.toHaveBeenCalled()
@@ -95,7 +95,7 @@ describe('when action throws an error', () => {
 
     const query = channel.subscribe()
 
-    await vi.runAllTimersAsync()
+    await vi.runOnlyPendingTimersAsync()
 
     expect(query.response).toBe(response)
     expect(query.error).toBeUndefined()
@@ -116,7 +116,7 @@ describe('when action throws an error', () => {
 
     channel.subscribe({ onSuccess, onError })
 
-    await vi.runAllTimersAsync()
+    await vi.runOnlyPendingTimersAsync()
     
     expect(onSuccess).not.toHaveBeenCalled()
     expect(onError).toHaveBeenCalledOnce()
@@ -130,13 +130,13 @@ test('active property is true whenever there are 1+ subscriptions', async () => 
 
   const first = channel.subscribe()
 
-  await vi.runAllTimersAsync()
+  await vi.runOnlyPendingTimersAsync()
 
   expect(channel.active).toBe(true)
   
   const second = channel.subscribe()
 
-  await vi.runAllTimersAsync()
+  await vi.runOnlyPendingTimersAsync()
 
   expect(channel.active).toBe(true)
 
@@ -196,7 +196,7 @@ describe('given channel with interval', () => {
       const willRemove = channel.subscribe({ interval: 5 })
       channel.subscribe({ interval: 20 })
 
-      await vi.runAllTimersAsync()
+      await vi.runOnlyPendingTimersAsync()
 
       // initial execution
       expect(action).toHaveBeenCalledTimes(1)
@@ -218,7 +218,7 @@ describe('given channel with interval', () => {
 
       channel.subscribe({ interval: 20 })
 
-      await vi.runAllTimersAsync()
+      await vi.runOnlyPendingTimersAsync()
 
       // initial execution
       expect(action).toHaveBeenCalledTimes(1)
@@ -242,7 +242,7 @@ describe('given channel with interval', () => {
 
       channel.subscribe({ interval: 20 })
 
-      await vi.runAllTimersAsync()
+      await vi.runOnlyPendingTimersAsync()
 
       // initial execution
       expect(action).toHaveBeenCalledTimes(1)

--- a/src/createChannel.spec.ts
+++ b/src/createChannel.spec.ts
@@ -253,9 +253,6 @@ describe('given channel with interval', () => {
       // add new, shorter interval
       channel.subscribe({ interval: 5 })
 
-      // run for new shortest, not enough to hit previous shortest
-      await vi.advanceTimersByTimeAsync(5)
-
       expect(action).toHaveBeenCalledTimes(2)
     })
   })

--- a/src/createChannel.spec.ts
+++ b/src/createChannel.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test, vi } from "vitest"
 import { createChannel } from "./createChannel"
-import { nextTick } from "vue"
+import { flushPromises } from "@vue/test-utils"
 
 test('subscribing to new channel, always executes the action', async () => {
   const response = Symbol('response')
@@ -10,7 +10,7 @@ test('subscribing to new channel, always executes the action', async () => {
 
   const query = channel.subscribe()
 
-  await nextTick()
+  await flushPromises()
 
   expect(query.response).toBe(response)
   expect(query.error).toBeUndefined()
@@ -29,7 +29,7 @@ test('additional subscription to existing channel, does not execute the action',
   // initial subscription
   channel.subscribe()
 
-  await nextTick()
+  await flushPromises()
   
   expect(action).toHaveBeenCalledOnce()
 
@@ -37,7 +37,7 @@ test('additional subscription to existing channel, does not execute the action',
     channel.subscribe()
   }
 
-  await nextTick()
+  await flushPromises()
 
   expect(action).toHaveBeenCalledOnce()
 })
@@ -51,7 +51,7 @@ describe('when action executes successfully', () => {
 
     const query = channel.subscribe()
 
-    await nextTick()
+    await flushPromises()
 
     expect(query.response).toBe(response)
     expect(query.error).toBeUndefined()
@@ -72,7 +72,7 @@ describe('when action executes successfully', () => {
   
     channel.subscribe({ onSuccess, onError })
   
-    await nextTick()
+    await flushPromises()
     
     expect(onSuccess).toHaveBeenCalledOnce()
     expect(onError).not.toHaveBeenCalled()
@@ -88,7 +88,7 @@ describe('when action throws an error', () => {
 
     const query = channel.subscribe()
 
-    await nextTick()
+    await flushPromises()
 
     expect(query.response).toBe(response)
     expect(query.error).toBeUndefined()
@@ -109,7 +109,7 @@ describe('when action throws an error', () => {
 
     channel.subscribe({ onSuccess, onError })
 
-    await nextTick()
+    await flushPromises()
     
     expect(onSuccess).not.toHaveBeenCalled()
     expect(onError).toHaveBeenCalledOnce()
@@ -123,13 +123,13 @@ test('active property is true whenever there are 1+ subscriptions', async () => 
 
   const first = channel.subscribe()
 
-  await nextTick()
+  await flushPromises()
 
   expect(channel.active).toBe(true)
   
   const second = channel.subscribe()
 
-  await nextTick()
+  await flushPromises()
 
   expect(channel.active).toBe(true)
 

--- a/src/createChannel.spec.ts
+++ b/src/createChannel.spec.ts
@@ -1,6 +1,13 @@
-import { describe, expect, test, vi } from "vitest"
+import { describe, expect, test, vi, beforeEach, afterEach } from "vitest"
 import { createChannel } from "./createChannel"
-import { flushPromises } from "@vue/test-utils"
+
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
 
 test('subscribing to new channel, always executes the action', async () => {
   const response = Symbol('response')
@@ -10,7 +17,7 @@ test('subscribing to new channel, always executes the action', async () => {
 
   const query = channel.subscribe()
 
-  await flushPromises()
+  await vi.runAllTimersAsync()
 
   expect(query.response).toBe(response)
   expect(query.error).toBeUndefined()
@@ -29,7 +36,7 @@ test('additional subscription to existing channel, does not execute the action',
   // initial subscription
   channel.subscribe()
 
-  await flushPromises()
+  await vi.runAllTimersAsync()
   
   expect(action).toHaveBeenCalledOnce()
 
@@ -37,7 +44,7 @@ test('additional subscription to existing channel, does not execute the action',
     channel.subscribe()
   }
 
-  await flushPromises()
+  await vi.runAllTimersAsync()
 
   expect(action).toHaveBeenCalledOnce()
 })
@@ -51,7 +58,7 @@ describe('when action executes successfully', () => {
 
     const query = channel.subscribe()
 
-    await flushPromises()
+    await vi.runAllTimersAsync()
 
     expect(query.response).toBe(response)
     expect(query.error).toBeUndefined()
@@ -72,7 +79,7 @@ describe('when action executes successfully', () => {
   
     channel.subscribe({ onSuccess, onError })
   
-    await flushPromises()
+    await vi.runAllTimersAsync()
     
     expect(onSuccess).toHaveBeenCalledOnce()
     expect(onError).not.toHaveBeenCalled()
@@ -88,7 +95,7 @@ describe('when action throws an error', () => {
 
     const query = channel.subscribe()
 
-    await flushPromises()
+    await vi.runAllTimersAsync()
 
     expect(query.response).toBe(response)
     expect(query.error).toBeUndefined()
@@ -109,7 +116,7 @@ describe('when action throws an error', () => {
 
     channel.subscribe({ onSuccess, onError })
 
-    await flushPromises()
+    await vi.runAllTimersAsync()
     
     expect(onSuccess).not.toHaveBeenCalled()
     expect(onError).toHaveBeenCalledOnce()
@@ -123,13 +130,13 @@ test('active property is true whenever there are 1+ subscriptions', async () => 
 
   const first = channel.subscribe()
 
-  await flushPromises()
+  await vi.runAllTimersAsync()
 
   expect(channel.active).toBe(true)
   
   const second = channel.subscribe()
 
-  await flushPromises()
+  await vi.runAllTimersAsync()
 
   expect(channel.active).toBe(true)
 
@@ -140,4 +147,116 @@ test('active property is true whenever there are 1+ subscriptions', async () => 
   second.dispose()
 
   expect(channel.active).toBe(false)
+})
+
+describe('given channel with interval', () => {
+  test('with single interval of 5, runs every 5ms', async () => {
+    const response = Symbol('response')
+    const action = vi.fn(() => response)
+    const channel = createChannel(action, [])
+
+    channel.subscribe({ interval: 5 })
+
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(action).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(5)
+
+    expect(action).toHaveBeenCalledTimes(2)
+  })
+
+  test.only('with multiple different intervals, runs at shortest', async () => {
+    const response = Symbol('response')
+    const action = vi.fn(() => response)
+    const channel = createChannel(action, [])
+
+    channel.subscribe({ interval: 10 })
+    channel.subscribe({ interval: 5 })
+    channel.subscribe({ interval: 20 })
+
+    await vi.advanceTimersByTimeAsync(0)
+
+    // initial execution
+    expect(action).toHaveBeenCalledTimes(1)
+
+    // shortest is 5, 50ms/5 = 10 times
+    await vi.advanceTimersByTimeAsync(50)
+
+    expect(action).toHaveBeenCalledTimes(11)
+  })
+
+  describe('and interval is removed', () => {
+    test('re-evaluates next interval', async () => {
+      const response = Symbol('response')
+      const action = vi.fn(() => response)
+      const channel = createChannel(action, [])
+
+      channel.subscribe({ interval: 10 })
+      const willRemove = channel.subscribe({ interval: 5 })
+      channel.subscribe({ interval: 20 })
+
+      await vi.runAllTimersAsync()
+
+      // initial execution
+      expect(action).toHaveBeenCalledTimes(1)
+
+      willRemove.dispose()
+
+      // new shortest is 10, 50ms/10 = 5 times
+      await vi.advanceTimersByTimeAsync(51)
+
+      expect(action).toHaveBeenCalledTimes(5)
+    })
+  })
+
+  describe('and new interval is added', () => {
+    test('re-evaluates next interval', async () => {
+      const response = Symbol('response')
+      const action = vi.fn(() => response)
+      const channel = createChannel(action, [])
+
+      channel.subscribe({ interval: 20 })
+
+      await vi.runAllTimersAsync()
+
+      // initial execution
+      expect(action).toHaveBeenCalledTimes(1)
+
+      // run without hitting interval
+      await vi.advanceTimersByTimeAsync(2)
+
+      // add new, shorter interval
+      channel.subscribe({ interval: 5 })
+
+      // run for new shortest, not enough to hit previous shortest
+      await vi.advanceTimersByTimeAsync(6)
+
+      expect(action).toHaveBeenCalledTimes(2)
+    })
+
+    test('with interval less than gap since last execution, runs immediately', async () => {
+      const response = Symbol('response')
+      const action = vi.fn(() => response)
+      const channel = createChannel(action, [])
+
+      channel.subscribe({ interval: 20 })
+
+      await vi.runAllTimersAsync()
+
+      // initial execution
+      expect(action).toHaveBeenCalledTimes(1)
+      
+      // run without hitting interval, longer than 5ms
+      await vi.advanceTimersByTimeAsync(8)
+
+      // add new, shorter interval
+      channel.subscribe({ interval: 5 })
+
+      // run for new shortest, not enough to hit previous shortest
+      await vi.advanceTimersByTimeAsync(5)
+
+      expect(action).toHaveBeenCalledTimes(2)
+    })
+  })
 })

--- a/src/createChannels.spec.ts
+++ b/src/createChannels.spec.ts
@@ -3,7 +3,6 @@ import { createChannels } from "./createChannels"
 import * as CreateChannelExports from './createChannel'
 import { QueryAction } from "./types/query"
 
-
 const getRandomNumber = () => Math.random()
 const multipleByTwo = (value: number) => value * 2
 
@@ -55,6 +54,7 @@ test('when createQuery is called, it should pass options through to the channel'
   vi.spyOn(CreateChannelExports, 'createChannel').mockReturnValue({
     subscribe,
     active: true
+    
   })
 
   const { createQuery } = createChannels()

--- a/src/createClient.spec.ts
+++ b/src/createClient.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect, vi, describe, afterEach, beforeEach } from 'vitest'
 import { createClient } from './createClient'
 import { flushPromises } from '@vue/test-utils'
-import { effectScope, nextTick, ref } from 'vue'
+import { effectScope, ref } from 'vue'
 import { timeout } from './utilities'
 
 beforeEach(() => {
@@ -149,7 +149,7 @@ describe('query', () => {
 
     expect(value.response).toBe(placeholder)
 
-    await nextTick()
+    await flushPromises()
 
     expect(value.response).toBe(response)
   })
@@ -170,13 +170,13 @@ describe('useQuery', () => {
 
       expect(query.response).toBe(undefined)
 
-      await nextTick()
+      await flushPromises()
 
       expect(query.response).toBe(responseFalse)
 
       input.value = true
 
-      await nextTick()
+      await flushPromises()
 
       expect(query.response).toBe(responseTrue)
     })
@@ -197,7 +197,7 @@ describe('useQuery', () => {
 
       const query = useQuery(action, () => [input.value])
 
-      await nextTick()
+      await flushPromises()
 
       expect(query.executing).toBe(true)
       expect(query.executed).toBe(false)
@@ -209,7 +209,7 @@ describe('useQuery', () => {
 
       input.value = true
 
-      await nextTick()
+      await flushPromises()
 
       expect(query.executing).toBe(true)
       expect(query.executed).toBe(false)
@@ -243,7 +243,7 @@ describe('useQuery', () => {
 
       parameters.value = [true]
 
-      await nextTick()
+      await flushPromises()
 
       parameters.value = null
 
@@ -251,7 +251,7 @@ describe('useQuery', () => {
 
       expect(query.response).toBe(placeholder)
       expect(query.executing).toBe(false)
-      expect(query.executed).toBe(true)
+      expect(query.executed).toBe(false)
     })
   })
 
@@ -302,7 +302,7 @@ describe('useQuery', () => {
 
     input.value = true
 
-    await nextTick()
+    await flushPromises()
 
     expect(query.response).toBe(responseFalse)
 
@@ -313,13 +313,13 @@ describe('useQuery', () => {
 
     input.value = true
 
-    await nextTick()
+    await flushPromises()
 
     expect(query.response).toBe(responseTrue)
 
     input.value = null
 
-    await nextTick()
+    await flushPromises()
 
     expect(query.response).toBeUndefined()
   })
@@ -347,7 +347,7 @@ describe('useQuery', () => {
 
     expect(value.response).toBe(placeholder)
 
-    await nextTick()
+    await flushPromises()
 
     expect(value.response).toBe(response)
   })

--- a/src/createClient.spec.ts
+++ b/src/createClient.spec.ts
@@ -1,6 +1,5 @@
 import { test, expect, vi, describe, afterEach, beforeEach } from 'vitest'
 import { createClient } from './createClient'
-import { flushPromises } from '@vue/test-utils'
 import { effectScope, ref } from 'vue'
 import { timeout } from './utilities'
 
@@ -29,7 +28,7 @@ describe('query', () => {
     query(action, [])
     query(action, [])
 
-    await flushPromises()
+    await vi.runAllTimersAsync()
 
     expect(action).toHaveBeenCalledOnce()
   })
@@ -59,7 +58,7 @@ describe('query', () => {
 
     expect(value.response).toBeUndefined()
 
-    await flushPromises()
+    await vi.runAllTimersAsync()
 
     expect(value.response).toBe(response)
   })
@@ -77,7 +76,7 @@ describe('query', () => {
     const { query } = createClient()
     const value = query(action, [])
 
-    await flushPromises()
+    await vi.runAllTimersAsync()
 
     expect(value.error).toBe(error)
   })
@@ -94,8 +93,7 @@ describe('query', () => {
 
     expect(value.response).toBeUndefined()
 
-    vi.runAllTimers()
-    await value
+    await vi.runAllTimersAsync()
 
     expect(value.response).toBe(response)
   })
@@ -113,6 +111,8 @@ describe('query', () => {
     const { query } = createClient()
     const value = query(action, [])
 
+    await vi.runAllTimersAsync()
+
     await expect(value).rejects.toBe(error)
   })
 
@@ -123,7 +123,7 @@ describe('query', () => {
 
     query(action, [], { onSuccess })
 
-    await flushPromises()
+    await vi.runAllTimersAsync()
 
     expect(onSuccess).toHaveBeenCalledOnce()
   })
@@ -135,7 +135,7 @@ describe('query', () => {
 
     query(action, [], { onError })
 
-    await flushPromises()
+    await vi.runAllTimersAsync()
 
     expect(onError).toHaveBeenCalledOnce()
   })
@@ -149,7 +149,7 @@ describe('query', () => {
 
     expect(value.response).toBe(placeholder)
 
-    await flushPromises()
+    await vi.runAllTimersAsync()
 
     expect(value.response).toBe(response)
   })
@@ -170,13 +170,13 @@ describe('useQuery', () => {
 
       expect(query.response).toBe(undefined)
 
-      await flushPromises()
+      await vi.runAllTimersAsync()
 
       expect(query.response).toBe(responseFalse)
 
       input.value = true
 
-      await flushPromises()
+      await vi.runAllTimersAsync()
 
       expect(query.response).toBe(responseTrue)
     })
@@ -197,7 +197,7 @@ describe('useQuery', () => {
 
       const query = useQuery(action, () => [input.value])
 
-      await flushPromises()
+      await vi.advanceTimersByTimeAsync(0)
 
       expect(query.executing).toBe(true)
       expect(query.executed).toBe(false)
@@ -209,7 +209,7 @@ describe('useQuery', () => {
 
       input.value = true
 
-      await flushPromises()
+      await vi.advanceTimersByTimeAsync(0)
 
       expect(query.executing).toBe(true)
       expect(query.executed).toBe(false)
@@ -243,7 +243,7 @@ describe('useQuery', () => {
 
       parameters.value = [true]
 
-      await flushPromises()
+      await vi.runAllTimersAsync()
 
       parameters.value = null
 
@@ -256,6 +256,7 @@ describe('useQuery', () => {
   })
 
   testInEffectScope('awaiting a query returns the response', async () => {
+    vi.useRealTimers()
     const response = Symbol('response')
     const action = vi.fn(() => response)
     const { useQuery } = createClient()
@@ -266,6 +267,7 @@ describe('useQuery', () => {
   })
 
   testInEffectScope('awaiting a query throws an error if the action throws an error', async () => {
+    vi.useRealTimers()
     const action = vi.fn(() => { throw new Error('test') })
     const { useQuery } = createClient()
     const value = useQuery(action, [])
@@ -295,31 +297,29 @@ describe('useQuery', () => {
 
     expect(query.response).toBeUndefined()
 
-    vi.runAllTimers()
-    await flushPromises()
+    await vi.runAllTimersAsync()
 
     expect(query.response).toBe(responseFalse)
 
     input.value = true
 
-    await flushPromises()
+    await vi.advanceTimersByTimeAsync(0)
 
     expect(query.response).toBe(responseFalse)
 
-    vi.runAllTimers()
-    await flushPromises()
+    await vi.runAllTimersAsync()
 
     expect(query.response).toBe(responseTrue)
 
     input.value = true
 
-    await flushPromises()
+    await vi.runAllTimersAsync()
 
     expect(query.response).toBe(responseTrue)
 
     input.value = null
 
-    await flushPromises()
+    await vi.runAllTimersAsync()
 
     expect(query.response).toBeUndefined()
   })
@@ -332,7 +332,7 @@ describe('useQuery', () => {
     const query1 = useQuery(action1, [])
     const query2 = useQuery(action2, [])
 
-    await flushPromises()
+    await vi.runAllTimersAsync()
 
     expect(query1.response).toBe(true)
     expect(query2.response).toBe(false)
@@ -347,7 +347,7 @@ describe('useQuery', () => {
 
     expect(value.response).toBe(placeholder)
 
-    await flushPromises()
+    await vi.runAllTimersAsync()
 
     expect(value.response).toBe(response)
   })
@@ -361,7 +361,9 @@ describe('defineQuery', () => {
 
     const { query } = defineQuery(action)
 
-    const value = await query([])
+    const value = query([])
+
+    await vi.runAllTimersAsync()
 
     expect(value.response).toBe(response)
   })
@@ -373,7 +375,9 @@ describe('defineQuery', () => {
 
     const { useQuery } = defineQuery(action)
 
-    const value = await useQuery([])
+    const value = useQuery([])
+
+    await vi.runAllTimersAsync()
 
     expect(value.response).toBe(response)
   })

--- a/src/createClient.spec.ts
+++ b/src/createClient.spec.ts
@@ -28,7 +28,7 @@ describe('query', () => {
     query(action, [])
     query(action, [])
 
-    await vi.runAllTimersAsync()
+    await vi.runOnlyPendingTimersAsync()
 
     expect(action).toHaveBeenCalledOnce()
   })
@@ -58,7 +58,7 @@ describe('query', () => {
 
     expect(value.response).toBeUndefined()
 
-    await vi.runAllTimersAsync()
+    await vi.runOnlyPendingTimersAsync()
 
     expect(value.response).toBe(response)
   })
@@ -76,7 +76,7 @@ describe('query', () => {
     const { query } = createClient()
     const value = query(action, [])
 
-    await vi.runAllTimersAsync()
+    await vi.runOnlyPendingTimersAsync()
 
     expect(value.error).toBe(error)
   })
@@ -111,7 +111,7 @@ describe('query', () => {
     const { query } = createClient()
     const value = query(action, [])
 
-    await vi.runAllTimersAsync()
+    await vi.runOnlyPendingTimersAsync()
 
     await expect(value).rejects.toBe(error)
   })
@@ -123,7 +123,7 @@ describe('query', () => {
 
     query(action, [], { onSuccess })
 
-    await vi.runAllTimersAsync()
+    await vi.runOnlyPendingTimersAsync()
 
     expect(onSuccess).toHaveBeenCalledOnce()
   })
@@ -135,7 +135,7 @@ describe('query', () => {
 
     query(action, [], { onError })
 
-    await vi.runAllTimersAsync()
+    await vi.runOnlyPendingTimersAsync()
 
     expect(onError).toHaveBeenCalledOnce()
   })
@@ -149,7 +149,7 @@ describe('query', () => {
 
     expect(value.response).toBe(placeholder)
 
-    await vi.runAllTimersAsync()
+    await vi.runOnlyPendingTimersAsync()
 
     expect(value.response).toBe(response)
   })
@@ -170,13 +170,13 @@ describe('useQuery', () => {
 
       expect(query.response).toBe(undefined)
 
-      await vi.runAllTimersAsync()
+      await vi.runOnlyPendingTimersAsync()
 
       expect(query.response).toBe(responseFalse)
 
       input.value = true
 
-      await vi.runAllTimersAsync()
+      await vi.runOnlyPendingTimersAsync()
 
       expect(query.response).toBe(responseTrue)
     })
@@ -202,7 +202,7 @@ describe('useQuery', () => {
       expect(query.executing).toBe(true)
       expect(query.executed).toBe(false)
 
-      await vi.runAllTimersAsync()
+      await vi.runOnlyPendingTimersAsync()
 
       expect(query.executing).toBe(false)
       expect(query.executed).toBe(true)
@@ -214,7 +214,7 @@ describe('useQuery', () => {
       expect(query.executing).toBe(true)
       expect(query.executed).toBe(false)
 
-      await vi.runAllTimersAsync()
+      await vi.runOnlyPendingTimersAsync()
 
       expect(query.executing).toBe(false)
       expect(query.executed).toBe(true)
@@ -243,11 +243,11 @@ describe('useQuery', () => {
 
       parameters.value = [true]
 
-      await vi.runAllTimersAsync()
+      await vi.runOnlyPendingTimersAsync()
 
       parameters.value = null
 
-      await vi.runAllTimersAsync()
+      await vi.runOnlyPendingTimersAsync()
 
       expect(query.response).toBe(placeholder)
       expect(query.executing).toBe(false)
@@ -307,19 +307,19 @@ describe('useQuery', () => {
 
     expect(query.response).toBe(responseFalse)
 
-    await vi.runAllTimersAsync()
+    await vi.runOnlyPendingTimersAsync()
 
     expect(query.response).toBe(responseTrue)
 
     input.value = true
 
-    await vi.runAllTimersAsync()
+    await vi.runOnlyPendingTimersAsync()
 
     expect(query.response).toBe(responseTrue)
 
     input.value = null
 
-    await vi.runAllTimersAsync()
+    await vi.runOnlyPendingTimersAsync()
 
     expect(query.response).toBeUndefined()
   })
@@ -332,7 +332,7 @@ describe('useQuery', () => {
     const query1 = useQuery(action1, [])
     const query2 = useQuery(action2, [])
 
-    await vi.runAllTimersAsync()
+    await vi.runOnlyPendingTimersAsync()
 
     expect(query1.response).toBe(true)
     expect(query2.response).toBe(false)
@@ -347,7 +347,7 @@ describe('useQuery', () => {
 
     expect(value.response).toBe(placeholder)
 
-    await vi.runAllTimersAsync()
+    await vi.runOnlyPendingTimersAsync()
 
     expect(value.response).toBe(response)
   })
@@ -363,7 +363,7 @@ describe('defineQuery', () => {
 
     const value = query([])
 
-    await vi.runAllTimersAsync()
+    await vi.runOnlyPendingTimersAsync()
 
     expect(value.response).toBe(response)
   })
@@ -377,7 +377,7 @@ describe('defineQuery', () => {
 
     const value = useQuery([])
 
-    await vi.runAllTimersAsync()
+    await vi.runOnlyPendingTimersAsync()
 
     expect(value.response).toBe(response)
   })

--- a/src/createClient.ts
+++ b/src/createClient.ts
@@ -35,7 +35,7 @@ export function createClient(options?: ClientOptions): QueryClient {
       if(parameters === null) {
         Object.assign(query, {
           response: toRef(() => options?.placeholder),
-          executed: false,
+          executed: toRef(() => false),
           executing: false,
         })
 

--- a/src/services/intervalController.spec.ts
+++ b/src/services/intervalController.spec.ts
@@ -15,7 +15,7 @@ test('given interval of Infinity, does not run', async () => {
 
   intervalController.set(action, Infinity)
 
-  await vi.runAllTimersAsync()
+  await vi.runOnlyPendingTimersAsync()
 
   expect(action).not.toHaveBeenCalled()
 
@@ -45,7 +45,7 @@ test('given interval that is later cancelled, does not run', async () => {
 
   intervalController.clear()
 
-  await vi.runAllTimersAsync()
+  await vi.runOnlyPendingTimersAsync()
 
   expect(action).not.toHaveBeenCalled()
 })

--- a/src/services/intervalController.spec.ts
+++ b/src/services/intervalController.spec.ts
@@ -1,0 +1,51 @@
+import { createIntervalController } from "./intervalController"
+import { vi, test, expect, beforeEach, afterEach } from "vitest"
+
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+test('given interval of Infinity, does not run', async () => {
+  const intervalController = createIntervalController()
+  const action = vi.fn()
+
+  intervalController.set(action, Infinity)
+
+  await vi.runAllTimersAsync()
+
+  expect(action).not.toHaveBeenCalled()
+
+  intervalController.clear()
+})
+
+test('given interval of 5, runs after 5ms', async () => {
+  const intervalController = createIntervalController()
+  const action = vi.fn()
+
+  intervalController.set(action, 5)
+
+  await vi.advanceTimersByTimeAsync(5)
+
+  expect(action).toHaveBeenCalledOnce()
+
+  intervalController.clear()
+})
+
+test('given interval that is later cancelled, does not run', async () => {
+  const intervalController = createIntervalController()
+  const action = vi.fn()
+
+  intervalController.set(action, 5)
+
+  await vi.advanceTimersByTimeAsync(4)
+
+  intervalController.clear()
+
+  await vi.runAllTimersAsync()
+
+  expect(action).not.toHaveBeenCalled()
+})

--- a/src/services/intervalController.ts
+++ b/src/services/intervalController.ts
@@ -1,13 +1,12 @@
-import { Getter } from "@/types/getters"
 import { QueryAction } from "@/types/query"
 
 export type IntervalController = {
-  set: (action: QueryAction, getInterval: Getter<number>) => void,
+  set: (action: QueryAction, interval: number) => void,
   clear: () => void,
 }
 
 export function createIntervalController(): IntervalController {
-  let timeout: ReturnType<typeof setInterval> | undefined
+  let timeout: ReturnType<typeof setTimeout> | undefined
 
   const clear: IntervalController['clear'] = () => {
     if(timeout) {
@@ -15,13 +14,11 @@ export function createIntervalController(): IntervalController {
     }
   }
 
-  const set: IntervalController['set'] = async (action, getInterval) => {
+  const set: IntervalController['set'] = async (action, interval) => {
     clear()
-    
-    const interval = getInterval()
 
     if(interval !== Infinity) {
-      timeout = setInterval(action, interval)
+      timeout = setTimeout(action, interval)
     }
   }
 

--- a/src/services/intervalController.ts
+++ b/src/services/intervalController.ts
@@ -1,38 +1,32 @@
 import { Getter } from "@/types/getters"
 import { QueryAction } from "@/types/query"
-import { Ref, ref } from "vue"
 
 export type IntervalController = {
-  execute: (action: QueryAction, getInterval: Getter<number>) => void,
+  set: (action: QueryAction, getInterval: Getter<number>) => void,
   clear: () => void,
-  lastExecuted: Ref<number | undefined>,
 }
 
 export function createIntervalController(): IntervalController {
-  const timeout = ref<ReturnType<typeof setInterval>>()
-  const lastExecuted = ref<number>()
+  let timeout: ReturnType<typeof setInterval> | undefined
 
-  const execute: IntervalController['execute'] = async (action, getInterval) => {
+  const clear: IntervalController['clear'] = () => {
+    if(timeout) {
+      clearInterval(timeout)
+    }
+  }
+
+  const set: IntervalController['set'] = async (action, getInterval) => {
     clear()
-    
-    await action()
-
-    lastExecuted.value = Date.now()
     
     const interval = getInterval()
 
     if(interval !== Infinity) {
-      timeout.value = setInterval(() => execute(action, getInterval), interval)
+      timeout = setInterval(action, interval)
     }
   }
 
-  const clear: IntervalController['clear'] = () => {
-    clearInterval(timeout.value)
-  }
-
   return {
-    execute,
+    set,
     clear,
-    lastExecuted,
   }
 }

--- a/src/services/intervalController.ts
+++ b/src/services/intervalController.ts
@@ -1,0 +1,38 @@
+import { Getter } from "@/types/getters"
+import { QueryAction } from "@/types/query"
+import { Ref, ref } from "vue"
+
+export type IntervalController = {
+  execute: (action: QueryAction, getInterval: Getter<number>) => void,
+  clear: () => void,
+  lastExecuted: Ref<number | undefined>,
+}
+
+export function createIntervalController(): IntervalController {
+  const timeout = ref<ReturnType<typeof setInterval>>()
+  const lastExecuted = ref<number>()
+
+  const execute: IntervalController['execute'] = async (action, getInterval) => {
+    clear()
+    
+    await action()
+
+    lastExecuted.value = Date.now()
+    
+    const interval = getInterval()
+
+    if(interval !== Infinity) {
+      timeout.value = setInterval(() => execute(action, getInterval), interval)
+    }
+  }
+
+  const clear: IntervalController['clear'] = () => {
+    clearInterval(timeout.value)
+  }
+
+  return {
+    execute,
+    clear,
+    lastExecuted,
+  }
+}

--- a/src/types/query.ts
+++ b/src/types/query.ts
@@ -10,6 +10,7 @@ export type QueryOptions<
   TAction extends QueryAction,
 > = {
   placeholder?: any,
+  interval?: number,
   onSuccess?: (value: Awaited<ReturnType<TAction>>) => void,
   onError?: (error: unknown) => void,
 }


### PR DESCRIPTION
- establish `IntervalController` service, just encapsulates responsibility of a couple small annoyances with `setTimeout`
- always runs `execute` through the `intervalController`, meaning tests have to use "advanceTimers" instead of "nextTick" and have to "useFakeTimers"

Interval Logic
- if many subscriptions with different intervals, takes the smallest
- whenever subscription is added or removed, next exec should be re-calculated
- if sub is added with interval shorter than time since last, should exec immediately