### PR TITLE
pull logic for creating composition out from createClient

### DIFF
--- a/src/createClient.ts
+++ b/src/createClient.ts
@@ -1,7 +1,4 @@
-import { onScopeDispose, toRef, toRefs, toValue, watch } from "vue";
 import { QueryAction, QueryOptions } from "./types/query";
-import isEqual from 'lodash.isequal'
-import { isDefined } from "./utilities";
 import { ClientOptions } from "./types/clientOptions";
 import { 
   DefinedQueryComposition,
@@ -12,8 +9,7 @@ import {
   QueryFunction,
 } from "./types/client";
 import { createQueryGroups } from "./createQueryGroups";
-
-const noop = () => undefined
+import { createUseQuery } from "./createUseQuery";
 
 export function createClient(options?: ClientOptions): QueryClient {
   const { createQuery } = createQueryGroups()
@@ -22,38 +18,8 @@ export function createClient(options?: ClientOptions): QueryClient {
     return createQuery(action, args, options)
   }
 
-  const useQuery: QueryComposition = (action, parameters, options) => {
-    const query = createQuery(noop, [], options)
-
-    watch(() => toValue(parameters), (parameters, previousParameters) => {
-      if(isDefined(previousParameters) && isEqual(previousParameters, parameters)) {
-        return
-      }
-
-      query.dispose()
-
-      if(parameters === null) {
-        Object.assign(query, {
-          response: toRef(() => options?.placeholder),
-          executed: toRef(() => false),
-          executing: false,
-        })
-
-        return
-      }
-
-      const newValue = createQuery(action, parameters, options)
-      const previousResponse = query.response
-
-      Object.assign(query, toRefs(newValue), {
-        response: toRef(() => newValue.response ?? previousResponse)
-      })
-          
-    }, { deep: true, immediate: true })
-
-    onScopeDispose(() => query.dispose())
-
-    return query
+  const useQuery: QueryComposition = (action, parameters, options) => {    
+    return createUseQuery(createQuery, action, parameters, options)
   }
 
   const defineQuery: DefineQuery = <

--- a/src/createUseQuery.ts
+++ b/src/createUseQuery.ts
@@ -13,8 +13,7 @@ export function createUseQuery<
   TOptions extends QueryCompositionOptions<TAction>
 >(createQuery: CreateQuery, action: TAction, parameters: TArgs, options?: TOptions): Query<TAction, TOptions>
 export function createUseQuery(createQuery: CreateQuery, action: QueryAction, parameters: unknown[], options: QueryCompositionOptions): Query<QueryAction, QueryOptions<QueryAction>> {
-  const { ttl, immediate, ...queryOptions } = options ?? {}
-  const query = createQuery(noop, [], queryOptions)
+  const query = createQuery(noop, [], options)
 
   watch(() => toValue(parameters), (parameters, previousParameters) => {
     if(isDefined(previousParameters) && isEqual(previousParameters, parameters)) {

--- a/src/createUseQuery.ts
+++ b/src/createUseQuery.ts
@@ -1,0 +1,48 @@
+import { CreateQuery } from "./createQueryGroups"
+import { QueryCompositionOptions } from "./types/client"
+import { Query, QueryAction, QueryActionArgs, QueryOptions } from "./types/query"
+import { onScopeDispose, toRef, toRefs, toValue, watch } from "vue"
+import isEqual from 'lodash.isequal'
+import { isDefined } from "./utilities"
+
+const noop = () => undefined
+
+export function createUseQuery<
+  TAction extends QueryAction,
+  TArgs extends QueryActionArgs<TAction>,
+  TOptions extends QueryCompositionOptions<TAction>
+>(createQuery: CreateQuery, action: TAction, parameters: TArgs, options?: TOptions): Query<TAction, TOptions>
+export function createUseQuery(createQuery: CreateQuery, action: QueryAction, parameters: unknown[], options: QueryCompositionOptions): Query<QueryAction, QueryOptions<QueryAction>> {
+  const { ttl, immediate, ...queryOptions } = options ?? {}
+  const query = createQuery(noop, [], queryOptions)
+
+  watch(() => toValue(parameters), (parameters, previousParameters) => {
+    if(isDefined(previousParameters) && isEqual(previousParameters, parameters)) {
+      return
+    }
+
+    query.dispose()
+
+    if(parameters === null) {
+      Object.assign(query, {
+        response: toRef(() => options?.placeholder),
+        executed: toRef(() => false),
+        executing: false,
+      })
+
+      return
+    }
+
+    const newValue = createQuery(action, parameters, options)
+    const previousResponse = query.response
+
+    Object.assign(query, toRefs(newValue), {
+      response: toRef(() => newValue.response ?? previousResponse)
+    })
+        
+  }, { deep: true, immediate: true })
+
+  onScopeDispose(() => query.dispose())
+
+  return query
+}


### PR DESCRIPTION
99% organizational change, should have no impact on functionality

1% useful overloads for future state where options for creating composition are slightly different than options for creating base query. 

These unique properties include `ttl` and `immediate`. I accidentally demonstrated and reverted by [this commit](https://github.com/kitbagjs/query/commit/f315ceb208ab2688f3c76545fe7a18664e5caf55). 

With the generics inside `TOptions` - if I try to change options for composition...

<img width="1063" alt="image" src="https://github.com/user-attachments/assets/64693d31-2929-430f-ad1d-0759d594d91a" />

...and without making the overload changes in this PR, I get the following error...

<img width="1104" alt="image" src="https://github.com/user-attachments/assets/505a843f-f941-4363-928a-911668a86a84" />
