### PR TITLE
add `immediate` property to composition options, acts as null params

### DIFF
--- a/src/createClient.spec.ts
+++ b/src/createClient.spec.ts
@@ -212,6 +212,21 @@ describe('query', () => {
     expect(value.executed).toBe(true)
     expect(action).toHaveBeenCalledTimes(2)
   })
+
+  test('immediate false has no effect when other queries in same group are immediate', async () => {
+    const response = Symbol('response')
+    const action = vi.fn(() => response)
+    const { query } = createClient()
+
+    const value = query(action, [], { immediate: false })
+    query(action, [])
+
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(value.response).toBe(response)
+    expect(value.executed).toBe(true)
+    expect(action).toHaveBeenCalledOnce()
+  })
 })
 
 describe('useQuery', () => {
@@ -465,6 +480,21 @@ describe('useQuery', () => {
     expect(query.response).toBe(response)
     expect(query.executed).toBe(true)
     expect(action).toHaveBeenCalledTimes(2)
+  })
+
+  testInEffectScope('immediate false has no effect when other queries in same group are immediate', async () => {
+    const response = Symbol('response')
+    const action = vi.fn(() => response)
+    const { useQuery } = createClient()
+
+    const query = useQuery(action, [], { immediate: false })
+    useQuery(action, [])
+
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(query.response).toBe(response)
+    expect(query.executed).toBe(true)
+    expect(action).toHaveBeenCalledOnce()
   })
 })
 

--- a/src/createClient.spec.ts
+++ b/src/createClient.spec.ts
@@ -351,6 +351,42 @@ describe('useQuery', () => {
 
     expect(value.response).toBe(response)
   })
+
+  testInEffectScope('immediate false, acts like null parameters', async () => {
+    const response = Symbol('response')
+    const input = ref<boolean | null>(null)
+
+    const action = vi.fn(async (_value: boolean) => {
+      await timeout(100)
+      return response
+    })
+    
+    const { useQuery } = createClient()
+
+    const query = useQuery(action, () => {
+      if(input.value === null) {
+        return null
+      }
+
+      return [input.value]
+    }, { immediate: false })
+
+    await vi.runAllTimersAsync()
+
+    expect(query.response).toBeUndefined()
+    expect(query.executed).toBe(false)
+    expect(query.executing).toBe(false)
+    expect(action).not.toHaveBeenCalled()
+
+    input.value = true
+
+    await vi.runAllTimersAsync()
+
+    expect(query.response).toBeUndefined()
+    expect(query.executed).toBe(false)
+    expect(query.executing).toBe(false)
+    expect(action).not.toHaveBeenCalled()
+  })
 })
 
 describe('defineQuery', () => {

--- a/src/createClient.spec.ts
+++ b/src/createClient.spec.ts
@@ -353,14 +353,8 @@ describe('useQuery', () => {
   })
 
   testInEffectScope('immediate false, acts like null parameters', async () => {
-    const response = Symbol('response')
     const input = ref<boolean | null>(null)
-
-    const action = vi.fn(async (_value: boolean) => {
-      await timeout(100)
-      return response
-    })
-    
+    const action = vi.fn((_value: boolean) => Symbol())
     const { useQuery } = createClient()
 
     const query = useQuery(action, () => {
@@ -379,6 +373,19 @@ describe('useQuery', () => {
     expect(action).not.toHaveBeenCalled()
 
     input.value = true
+
+    await vi.runAllTimersAsync()
+
+    expect(query.response).toBeUndefined()
+    expect(query.executed).toBe(false)
+    expect(query.executing).toBe(false)
+    expect(action).not.toHaveBeenCalled()
+  })
+
+  testInEffectScope('immediate false, also prevents interval', async () => {
+    const action = vi.fn(() => Symbol())
+    const { useQuery } = createClient()
+    const query = useQuery(action, [], { immediate: false, interval: 100 })
 
     await vi.runAllTimersAsync()
 

--- a/src/createClient.spec.ts
+++ b/src/createClient.spec.ts
@@ -482,6 +482,36 @@ describe('useQuery', () => {
     expect(action).toHaveBeenCalledTimes(2)
   })
 
+  testInEffectScope('immediate false has no effect after calling execute, even when args change', async () => {
+    const responseTrue = Symbol('responseTrue')
+    const responseFalse = Symbol('responseFalse')
+    const input = ref(false)
+
+    const action = vi.fn((value: boolean) => value ? responseTrue : responseFalse)
+
+    const { useQuery } = createClient()
+    const query = useQuery(action, () => [input.value], { immediate: false })
+
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(query.response).toBeUndefined()
+    expect(action).not.toHaveBeenCalled()
+
+    await query.execute()
+
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(query.response).toBe(responseFalse)
+    expect(action).toHaveBeenCalledTimes(1)
+
+    input.value = true
+
+    await vi.runOnlyPendingTimersAsync()
+
+    expect(query.response).toBe(responseTrue)
+    expect(action).toHaveBeenCalledTimes(2)
+  })
+
   testInEffectScope('immediate false has no effect when other queries in same group are immediate', async () => {
     const response = Symbol('response')
     const action = vi.fn(() => response)

--- a/src/createQueryGroup.ts
+++ b/src/createQueryGroup.ts
@@ -120,7 +120,7 @@ export function createQueryGroup<
   function addSubscription(options?: QueryOptions<TAction>): () => void {
     const id = nextId()
 
-    subscriptions.set(id, options ?? {})  
+    subscriptions.set(id, { immediate: true, ...options })  
 
     setNextExecution()
     addTags(options?.tags)
@@ -139,7 +139,7 @@ export function createQueryGroup<
 
   function getNextSubscriptionInterval(): number {
     if(lastExecuted === undefined) {
-      return 0
+      return getIsImmediate() ? 0 : Infinity
     }
 
     const interval = getSubscriptionInterval()
@@ -154,6 +154,12 @@ export function createQueryGroup<
       .map(subscription => subscription.interval ?? Infinity)
   
     return Math.min(...intervals)
+  }
+
+  function getIsImmediate(): boolean {
+    return Array
+      .from(subscriptions.values())
+      .some(subscription => subscription.immediate)
   }
 
   function subscribe<

--- a/src/createUseQuery.ts
+++ b/src/createUseQuery.ts
@@ -1,4 +1,5 @@
 import { CreateQuery } from "./createQueryGroups"
+import { QueryCompositionOptions } from "./types/client"
 import { Query, QueryAction, QueryActionArgs, QueryOptions } from "./types/query"
 import { onScopeDispose, toRef, toRefs, toValue, watch } from "vue"
 import isEqual from 'lodash.isequal'
@@ -9,10 +10,11 @@ const noop = () => undefined
 export function createUseQuery<
   TAction extends QueryAction,
   TArgs extends QueryActionArgs<TAction>,
-  TOptions extends QueryOptions<TAction>
+  TOptions extends QueryCompositionOptions<TAction>
 >(createQuery: CreateQuery, action: TAction, parameters: TArgs, options?: TOptions): Query<TAction, TOptions>
-export function createUseQuery(createQuery: CreateQuery, action: QueryAction, parameters: unknown[], options: QueryOptions<QueryAction>): Query<QueryAction, QueryOptions<QueryAction>> {
-  const query = createQuery(noop, [], options)
+export function createUseQuery(createQuery: CreateQuery, action: QueryAction, parameters: unknown[], options: QueryCompositionOptions<QueryAction>): Query<QueryAction, QueryOptions<QueryAction>> {
+  const { immediate = true, ...queryOptions } = options ?? {}
+  const query = createQuery(noop, [], queryOptions)
 
   watch(() => toValue(parameters), (parameters, previousParameters) => {
     if(isDefined(previousParameters) && isEqual(previousParameters, parameters)) {
@@ -21,7 +23,7 @@ export function createUseQuery(createQuery: CreateQuery, action: QueryAction, pa
 
     query.dispose()
 
-    if(parameters === null) {
+    if(parameters === null || !immediate) {
       Object.assign(query, {
         response: toRef(() => options?.placeholder),
         executed: toRef(() => false),

--- a/src/createUseQuery.ts
+++ b/src/createUseQuery.ts
@@ -1,5 +1,4 @@
 import { CreateQuery } from "./createQueryGroups"
-import { QueryCompositionOptions } from "./types/client"
 import { Query, QueryAction, QueryActionArgs, QueryOptions } from "./types/query"
 import { onScopeDispose, toRef, toRefs, toValue, watch } from "vue"
 import isEqual from 'lodash.isequal'
@@ -10,11 +9,10 @@ const noop = () => undefined
 export function createUseQuery<
   TAction extends QueryAction,
   TArgs extends QueryActionArgs<TAction>,
-  TOptions extends QueryCompositionOptions<TAction>
+  TOptions extends QueryOptions<TAction>
 >(createQuery: CreateQuery, action: TAction, parameters: TArgs, options?: TOptions): Query<TAction, TOptions>
-export function createUseQuery(createQuery: CreateQuery, action: QueryAction, parameters: unknown[], options: QueryCompositionOptions<QueryAction>): Query<QueryAction, QueryOptions<QueryAction>> {
-  const { immediate = true, ...queryOptions } = options ?? {}
-  const query = createQuery(noop, [], queryOptions)
+export function createUseQuery(createQuery: CreateQuery, action: QueryAction, parameters: unknown[], options: QueryOptions<QueryAction>): Query<QueryAction, QueryOptions<QueryAction>> {
+  const query = createQuery(noop, [], options)
 
   watch(() => toValue(parameters), (parameters, previousParameters) => {
     if(isDefined(previousParameters) && isEqual(previousParameters, parameters)) {
@@ -23,7 +21,7 @@ export function createUseQuery(createQuery: CreateQuery, action: QueryAction, pa
 
     query.dispose()
 
-    if(parameters === null || !immediate) {
+    if(parameters === null) {
       Object.assign(query, {
         response: toRef(() => options?.placeholder),
         executed: toRef(() => false),

--- a/src/createUseQuery.ts
+++ b/src/createUseQuery.ts
@@ -13,12 +13,14 @@ export function createUseQuery<
 >(createQuery: CreateQuery, action: TAction, parameters: TArgs, options?: TOptions): Query<TAction, TOptions>
 export function createUseQuery(createQuery: CreateQuery, action: QueryAction, parameters: unknown[], options: QueryOptions<QueryAction>): Query<QueryAction, QueryOptions<QueryAction>> {
   const query = createQuery(noop, [], options)
+  let hasExecuted = false
 
   watch(() => toValue(parameters), (parameters, previousParameters) => {
     if(isDefined(previousParameters) && isEqual(previousParameters, parameters)) {
       return
     }
 
+    hasExecuted = query.executed
     query.dispose()
 
     if(parameters === null) {
@@ -31,7 +33,7 @@ export function createUseQuery(createQuery: CreateQuery, action: QueryAction, pa
       return
     }
 
-    const newValue = createQuery(action, parameters, options)
+    const newValue = createQuery(action, parameters, hasExecuted ? {...options, immediate: true} : options)
     const previousResponse = query.response
 
     Object.assign(query, toRefs(newValue), {

--- a/src/types/client.ts
+++ b/src/types/client.ts
@@ -19,10 +19,16 @@ export type DefinedQueryFunction<
   TOptions extends QueryOptions<TAction>
 > = (args: Parameters<TAction>, options?: TOptions) => Query<TAction, TOptions>
 
+export type QueryCompositionOptions<
+  TAction extends QueryAction
+> = QueryOptions<TAction> & {
+  immediate?: boolean,
+}
+
 export type QueryComposition = <
   const TAction extends QueryAction,
   const Args extends QueryActionArgs<TAction>,
-  const TOptions extends QueryOptions<TAction>
+  const TOptions extends QueryCompositionOptions<TAction>
 >(action: TAction, args: Args, options?: TOptions) => Query<TAction, TOptions>
 
 export type DefinedQueryComposition<

--- a/src/types/client.ts
+++ b/src/types/client.ts
@@ -19,16 +19,10 @@ export type DefinedQueryFunction<
   TOptions extends QueryOptions<TAction>
 > = (args: Parameters<TAction>, options?: TOptions) => Query<TAction, TOptions>
 
-export type QueryCompositionOptions<
-  TAction extends QueryAction
-> = QueryOptions<TAction> & {
-  immediate?: boolean,
-}
-
 export type QueryComposition = <
   const TAction extends QueryAction,
   const Args extends QueryActionArgs<TAction>,
-  const TOptions extends QueryCompositionOptions<TAction>
+  const TOptions extends QueryOptions<TAction>
 >(action: TAction, args: Args, options?: TOptions) => Query<TAction, TOptions>
 
 export type DefinedQueryComposition<

--- a/src/types/query.ts
+++ b/src/types/query.ts
@@ -12,6 +12,7 @@ export type QueryOptions<
 > = {
   placeholder?: any,
   interval?: number,
+  immediate?: boolean,
   onSuccess?: (value: Awaited<ReturnType<TAction>>) => void,
   onError?: (error: unknown) => void,
   tags?: QueryTag[] | ((value: Awaited<ReturnType<TAction>>) => QueryTag[])


### PR DESCRIPTION
This PR establishes a superset of options specifically for `useQuery`. This will be useful for features that exist in the composition context but not in regular queries. 

This PR also establishes the first of these properties, `immediate: boolean`. When a user passes `{ immediate: false }`, it will prevent initial execution, exactly like passing `null` as params.