### PR TITLE
Add retries to query options

### DIFF
--- a/src/createClient.spec.ts
+++ b/src/createClient.spec.ts
@@ -382,3 +382,26 @@ describe('defineQuery', () => {
     expect(value.response).toBe(response)
   })
 })
+
+describe('options', () => {
+  test('retries', async () => {
+    const action = vi.fn(() => { throw new Error('test') })
+    const { query } = createClient({ retries: { count: 1, delay: 100 }})
+
+    const result = query(action, [])
+
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(action).toHaveBeenCalledTimes(1)
+    expect(result.error).toBeUndefined()
+    expect(result.errored).toBe(false)
+    expect(result.executed).toBe(false)
+
+    await vi.advanceTimersByTimeAsync(100)
+
+    expect(action).toHaveBeenCalledTimes(2)
+    expect(result.error).toBeDefined()
+    expect(result.errored).toBe(true)
+    expect(result.executed).toBe(true)
+  })
+})

--- a/src/createClient.spec.ts
+++ b/src/createClient.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect, vi, describe, afterEach, beforeEach } from 'vitest'
 import { createClient } from './createClient'
 import { effectScope, ref } from 'vue'
-import { timeout } from './utilities'
+import { timeout } from './utilities/timeout'
 
 beforeEach(() => {
   vi.useFakeTimers()

--- a/src/createClient.ts
+++ b/src/createClient.ts
@@ -12,7 +12,7 @@ import { createQueryGroups } from "./createQueryGroups";
 import { createUseQuery } from "./createUseQuery";
 
 export function createClient(options?: ClientOptions): QueryClient {
-  const { createQuery } = createQueryGroups()
+  const { createQuery } = createQueryGroups(options)
 
   const query: QueryFunction = (action, args, options) => {
     return createQuery(action, args, options)

--- a/src/createQueryGroup.spec.ts
+++ b/src/createQueryGroup.spec.ts
@@ -335,3 +335,26 @@ describe('execute', () => {
     await expect(response).rejects.toThrow('Expected error')
   })
 })
+
+describe('retries', () => {
+  test('retries the action', async () => {
+    const action = vi.fn(() => { throw new Error('Expected error') })
+    const group = createQueryGroup(action, [])
+
+    const result = group.subscribe({ retries: { count: 1, delay: 100 }})
+
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(action).toHaveBeenCalledTimes(1)
+    expect(result.error).toBeUndefined()
+    expect(result.errored).toBe(false)
+    expect(result.executed).toBe(false)
+
+    await vi.advanceTimersByTimeAsync(100)
+
+    expect(action).toHaveBeenCalledTimes(2)
+    expect(result.error).toBeDefined()
+    expect(result.errored).toBe(true)
+    expect(result.executed).toBe(true)
+  })
+})

--- a/src/createQueryGroup.ts
+++ b/src/createQueryGroup.ts
@@ -16,9 +16,13 @@ export type QueryGroup<
   active: boolean,
 }
 
+export type QueryGroupOptions = {
+  retries?: number | Partial<RetryOptions>
+}
+
 export function createQueryGroup<
   TAction extends QueryAction,
->(action: TAction, parameters: Parameters<TAction>): QueryGroup<TAction> {
+>(action: TAction, parameters: Parameters<TAction>, options?: QueryGroupOptions): QueryGroup<TAction> {
   type Group = Query<TAction, QueryOptions<TAction>>
 
   const intervalController = createIntervalController()
@@ -161,6 +165,8 @@ export function createQueryGroup<
     const retries = Array
       .from(subscriptions.values())
       .map(subscription => subscription.retries)
+    
+    retries.push(options?.retries)
 
     return reduceRetryOptions(retries)
   }

--- a/src/createQueryGroups.spec.ts
+++ b/src/createQueryGroups.spec.ts
@@ -55,6 +55,7 @@ test('when createQuery is called, it should pass options through to the group', 
     subscribe,
     active: true,
     hasTag: vi.fn(),
+    execute: vi.fn(),
   })
 
   const { createQuery } = createQueryGroups()

--- a/src/createQueryGroups.ts
+++ b/src/createQueryGroups.ts
@@ -1,4 +1,4 @@
-import { QueryGroup, createQueryGroup } from "./createQueryGroup";
+import { QueryGroup, QueryGroupOptions, createQueryGroup } from "./createQueryGroup";
 import { createSequence } from "./createSequence";
 import { Query, QueryAction, QueryOptions } from "./types/query";
 
@@ -13,7 +13,7 @@ export type CreateQueryGroups = {
   createQuery: CreateQuery
 }
 
-export function createQueryGroups() {
+export function createQueryGroups(options?: QueryGroupOptions) {
   const createActionId = createSequence()
   const actions = new Map<QueryAction, number>()
   const groups = new Map<QueryGroupKey, QueryGroup>()
@@ -34,7 +34,7 @@ export function createQueryGroups() {
     const queryKey = createGroupKey(action, parameters)
 
     if(!groups.has(queryKey)) {
-      groups.set(queryKey, createQueryGroup(action, parameters))
+      groups.set(queryKey, createQueryGroup(action, parameters, options))
     }
 
     return groups.get(queryKey)!

--- a/src/types/clientOptions.ts
+++ b/src/types/clientOptions.ts
@@ -1,4 +1,6 @@
-export type ClientOptions = {
-  pauseActionsInBackground: boolean
+import { QueryGroupOptions } from "@/createQueryGroup"
+
+export type ClientOptions = QueryGroupOptions & {
+  pauseActionsInBackground?: boolean
 }
 

--- a/src/types/query.ts
+++ b/src/types/query.ts
@@ -1,3 +1,4 @@
+import { RetryOptions } from "@/utilities/retry";
 import { Getter, MaybeGetter } from "./getters";
 import { QueryTag } from "@/types/tags";
 
@@ -15,6 +16,7 @@ export type QueryOptions<
   onSuccess?: (value: Awaited<ReturnType<TAction>>) => void,
   onError?: (error: unknown) => void,
   tags?: QueryTag[] | ((value: Awaited<ReturnType<TAction>>) => QueryTag[])
+  retries?: number | Partial<RetryOptions>,
 }
 
 export type ExtractQueryOptionsFromQuery<

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -1,7 +1,3 @@
 export function isDefined<T>(value: T | undefined): value is T {
   return typeof value !== 'undefined'
 }
-
-export function timeout(ms?: number) {
-  return new Promise(resolve => setTimeout(resolve, ms))
-}

--- a/src/utilities/retry.spec.ts
+++ b/src/utilities/retry.spec.ts
@@ -1,29 +1,62 @@
-import { expect, test, vi } from "vitest";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
 import { retry } from "./retry";
 
-test('should not retry callback if it does not throw an error', async () => {
-  const callback = vi.fn()
-
-  await retry(callback)
-
-  expect(callback).toHaveBeenCalledOnce()
+beforeEach(() => {
+  vi.useFakeTimers()
 })
 
-test('should retry callback if it throws an error', async () => {
-  vi.useFakeTimers()
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+test('should not retry callback if it does not throw an error and resolve the promise', async () => {
+  const callback = vi.fn()
+
+  const result = retry(callback)
+
+  expect(callback).toHaveBeenCalledOnce()
+
+  await expect(result).resolves.toBeUndefined()
+})
+
+test('should retry callback if it throws an error and resolve the promise if it then succeeds', async () => {
+  let count = 1
 
   const callback = vi.fn(() => {
-    throw new Error('test')
+    if(count === 1) {
+      count++
+      throw new Error('test')
+    }
+
+    return 'success'
   })
 
-  const result = retry(callback, { retries: 3, delay: 100 })
+  const result = retry(callback, { retries: 1, delay: 100 })
+
+  await vi.advanceTimersByTimeAsync(100)
+
+  expect(callback).toHaveBeenCalledTimes(2)
+
+  await expect(result).resolves.toBe('success')
+})
+
+test('should retry callback if it throws an error and reject the promise if it then fails', async () => {
+  const error = new Error('test')
+  const callback = vi.fn(() => {
+    throw error
+  })
+
+  retry(callback, { retries: 3, delay: 100 }).catch(error => {
+    expect(error).toBe(error)
+
+    return 'error'
+  })
+  
+  await vi.advanceTimersByTimeAsync(0)
 
   expect(callback).toHaveBeenCalled()
-  vi.resetAllMocks()
 
   await vi.advanceTimersByTimeAsync(300)
 
-  expect(callback).toHaveBeenCalledTimes(3)
-
-  await expect(result).rejects.toThrow('test')
+  expect(callback).toHaveBeenCalledTimes(4)
 })

--- a/src/utilities/retry.spec.ts
+++ b/src/utilities/retry.spec.ts
@@ -56,7 +56,7 @@ describe('retry', () => {
     
     await vi.advanceTimersByTimeAsync(0)
 
-    expect(callback).toHaveBeenCalled()
+    expect(callback).toHaveBeenCalledOnce()
 
     await vi.advanceTimersByTimeAsync(300)
 

--- a/src/utilities/retry.spec.ts
+++ b/src/utilities/retry.spec.ts
@@ -1,0 +1,29 @@
+import { expect, test, vi } from "vitest";
+import { retry } from "./retry";
+
+test('should not retry callback if it does not throw an error', async () => {
+  const callback = vi.fn()
+
+  await retry(callback)
+
+  expect(callback).toHaveBeenCalledOnce()
+})
+
+test('should retry callback if it throws an error', async () => {
+  vi.useFakeTimers()
+
+  const callback = vi.fn(() => {
+    throw new Error('test')
+  })
+
+  const result = retry(callback, { retries: 3, delay: 100 })
+
+  expect(callback).toHaveBeenCalled()
+  vi.resetAllMocks()
+
+  await vi.advanceTimersByTimeAsync(300)
+
+  expect(callback).toHaveBeenCalledTimes(3)
+
+  await expect(result).rejects.toThrow('test')
+})

--- a/src/utilities/retry.ts
+++ b/src/utilities/retry.ts
@@ -53,6 +53,6 @@ export async function retry<T>(action: RetryCallback<T>, options: RetryOptions, 
 
     await timeout(delay)
 
-    return await retry(action, options, count + 1)
+    return retry(action, options, count + 1)
   }
 }

--- a/src/utilities/retry.ts
+++ b/src/utilities/retry.ts
@@ -1,0 +1,27 @@
+import { timeout } from "./timeout"
+
+type RetryCallback<T> = () => T
+
+type RetryOptions = {
+  retries?: number,
+  delay?: number,
+}
+
+const DEFAULT_RETRIES = 0
+const DEFAULT_DELAY = 1000
+
+export async function retry<T>(action: RetryCallback<T>, options: RetryOptions = {}, count: number = 0): Promise<T> {
+  const { retries = DEFAULT_RETRIES, delay = DEFAULT_DELAY } = options
+
+  try {
+    return await action()
+  } catch(error) {
+    if(count >= retries) {
+      throw error
+    }
+
+    await timeout(delay)
+
+    return await retry(action, options, count + 1)
+  }
+}

--- a/src/utilities/retry.ts
+++ b/src/utilities/retry.ts
@@ -14,10 +14,7 @@ export const DEFAULT_RETRY_OPTIONS: RetryOptions = {
 
 function normalizeRetryOptions(options: Partial<RetryOptions> | number | undefined): RetryOptions {
   if(typeof options === 'number') {
-    return {
-      ...DEFAULT_RETRY_OPTIONS,
-      count: options,
-    }
+     return normalizeRetryOptions({count: options})
   }
 
   if(typeof options === 'object') {

--- a/src/utilities/timeout.ts
+++ b/src/utilities/timeout.ts
@@ -1,0 +1,3 @@
+export function timeout(ms?: number) {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}


### PR DESCRIPTION
# Description
Adds a new query option named `retries`. Which can be `number | RetryOptions`. If set to a number greater than 0 the action will automatically be retried after a set delay. It will be retried equal to the value given. `RetryOptions` can be used to customize both the number of retries `retries.count` and the delay `retries.delay`. 

```ts
const result = query(action, args, {
  retries: { count: 3, delay: 500 }
})
```

The default retries value is `{ count: 0, delay: 500 }` but this can be customized using the new `ClientOptions` when creating a client.

```ts
const { query } = createClient({
  retries: { count: 3, delay: 100 }
})
```