### PR TITLE
Add `immediate` option to `useQuery`

### DIFF
--- a/src/types/client.ts
+++ b/src/types/client.ts
@@ -19,10 +19,14 @@ export type DefinedQueryFunction<
   TOptions extends QueryOptions<TAction>
 > = (args: Parameters<TAction>, options?: TOptions) => Query<TAction, TOptions>
 
+export type UseQueryOptions<TAction extends QueryAction> = QueryOptions<TAction> & {
+  immediate?: boolean,
+}
+
 export type QueryComposition = <
   const TAction extends QueryAction,
   const Args extends QueryActionArgs<TAction>,
-  const TOptions extends QueryOptions<TAction>
+  const TOptions extends UseQueryOptions<TAction>
 >(action: TAction, args: Args, options?: TOptions) => Query<TAction, TOptions>
 
 export type DefinedQueryComposition<


### PR DESCRIPTION
# Description
Alternate take on https://github.com/kitbagjs/query/pull/18 that only adds the `immediate` option to `useQuery` rather than adding it to the channel itself. That way it acts almost exactly like `null` args. 