### PR TITLE
Optimize tag storage on query groups

### DIFF
--- a/src/createQueryClient.spec.ts
+++ b/src/createQueryClient.spec.ts
@@ -429,7 +429,7 @@ describe('useQuery', () => {
 
       expect(action).toHaveBeenCalled()
       expect(query.data).toBe(response)
-      expect(result).resolves.toBe(response)
+      await expect(result).resolves.toBe(response)
     })
 
     testInEffectScope('when false, execute rejects with the error', async () => {

--- a/src/createQueryGroup.ts
+++ b/src/createQueryGroup.ts
@@ -37,7 +37,7 @@ export function createQueryGroup<
   const { promise, resolve } = Promise.withResolvers()
 
   const subscriptions = new Map<number, QueryOptions<TAction>>()
-  const nextId = createSequence()
+  const createSubscriptionId = createSequence()
   const tags = createQueryGroupTags()
 
   async function execute(): Promise<AwaitedQuery<TAction>> {
@@ -116,7 +116,7 @@ export function createQueryGroup<
       return addTags(tags, id)
     }
 
-    tags.addAll(tagsToAdd, id)
+    tags.addAllTags(tagsToAdd, id)
   }
 
   function hasTag(tag: QueryTag): boolean {
@@ -124,16 +124,16 @@ export function createQueryGroup<
   }
 
   function addSubscription(options?: QueryOptions<TAction>): () => void {
-    const id = nextId()
+    const subscriptionId = createSubscriptionId()
 
-    subscriptions.set(id, options ?? {})  
+    subscriptions.set(subscriptionId, options ?? {})  
 
     setNextExecution()
-    addTags(options?.tags, id)
+    addTags(options?.tags, subscriptionId)
 
     return () => {
-      subscriptions.delete(id)
-      tags.removeAllById(id)
+      subscriptions.delete(subscriptionId)
+      tags.removeAllTagsBySubscriptionId(subscriptionId)
     }
   }
 

--- a/src/createQueryGroup.ts
+++ b/src/createQueryGroup.ts
@@ -3,9 +3,10 @@ import { AwaitedQuery, Query, QueryAction, QueryOptions } from "./types/query";
 import { createSequence } from "./createSequence";
 import { QueryError } from "./queryError";
 import { createIntervalController } from "./services/intervalController";
-import { QueryTagKey, QueryTag } from "./types/tags";
+import { QueryTag } from "./types/tags";
 import { log } from "./services/loggingService";
 import { reduceRetryOptions, retry, RetryOptions } from "./utilities/retry";
+import { createQueryGroupTags } from "./createQueryGroupTags";
 
 export type QueryGroup<
   TAction extends QueryAction = QueryAction,
@@ -37,7 +38,7 @@ export function createQueryGroup<
 
   const subscriptions = new Map<number, QueryOptions<TAction>>()
   const nextId = createSequence()
-  const tags = new Set<QueryTagKey>()
+  const tags = createQueryGroupTags()
 
   async function execute(): Promise<AwaitedQuery<TAction>> {
     lastExecuted = Date.now()
@@ -95,12 +96,12 @@ export function createQueryGroup<
   function setTags(): void {
     tags.clear()
 
-    for(const { tags } of subscriptions.values()) {
-      addTags(tags)
+    for(const [id, { tags }] of subscriptions.entries()) {
+      addTags(tags, id)
     }
   }
 
-  function addTags(tagsToAdd: QueryOptions<TAction>['tags'] = []): void {
+  function addTags(tagsToAdd: QueryOptions<TAction>['tags'], id: number): void {
     if(lastExecuted === undefined) {
       return
     }
@@ -112,14 +113,14 @@ export function createQueryGroup<
     if(typeof tagsToAdd === 'function') {
       const tags = tagsToAdd(data.value)
       
-      return addTags(tags)
+      return addTags(tags, id)
     }
 
-    tagsToAdd.forEach(tag => tags.add(tag.key))
+    tags.addAll(tagsToAdd, id)
   }
 
   function hasTag(tag: QueryTag): boolean {
-    return tags.has(tag.key)
+    return tags.has(tag)
   }
 
   function addSubscription(options?: QueryOptions<TAction>): () => void {
@@ -128,11 +129,11 @@ export function createQueryGroup<
     subscriptions.set(id, options ?? {})  
 
     setNextExecution()
-    addTags(options?.tags)
+    addTags(options?.tags, id)
 
     return () => {
       subscriptions.delete(id)
-      setTags()
+      tags.removeAllById(id)
     }
   }
 

--- a/src/createQueryGroupTags.spec.ts
+++ b/src/createQueryGroupTags.spec.ts
@@ -1,0 +1,62 @@
+import { createQueryGroupTags } from './createQueryGroupTags'
+import { test, expect } from 'vitest'
+import { tag } from '@/tag'
+
+test('should add and check tags correctly', () => {
+  const tags = createQueryGroupTags()
+  const tag1 = tag('test')
+  
+  tags.addAll([tag1], 1)
+
+  expect(tags.has(tag1)).toBe(true)
+})
+
+test('should remove tags correctly', () => {
+  const tags = createQueryGroupTags()
+  const tag1 = tag('test')
+  
+  tags.addAll([tag1], 1)
+  tags.removeAllById(1)
+  
+  expect(tags.has(tag1)).toBe(false)
+})
+
+test('should handle multiple tags and ids', () => {
+  const tags = createQueryGroupTags()
+  const tag1 = tag('test1')
+  const tag2 = tag('test2')
+  
+  tags.addAll([tag1, tag2], 1)
+  tags.addAll([tag1], 2)
+  
+  expect(tags.has(tag1)).toBe(true)
+  expect(tags.has(tag2)).toBe(true)
+  
+  tags.removeAllById(1)
+
+  expect(tags.has(tag2)).toBe(false)
+  expect(tags.has(tag1)).toBe(true)
+})
+
+test('should clear all tags', () => {
+  const tags = createQueryGroupTags()
+  const tag1 = tag('test1')
+  const tag2 = tag('test2')
+  const tag3 = tag('test3')
+  
+  tags.addAll([tag1, tag2], 1)
+  tags.addAll([tag1, tag2, tag3], 2)
+  tags.clear()
+  
+  expect(tags.has(tag1)).toBe(false)
+  expect(tags.has(tag2)).toBe(false)
+  expect(tags.has(tag3)).toBe(false)
+})
+
+test('should handle undefined tags gracefully', () => {
+  const groupTags = createQueryGroupTags()
+  
+  expect(() => {
+    groupTags.addAll(undefined, 1)
+  }).not.toThrow()
+})

--- a/src/createQueryGroupTags.ts
+++ b/src/createQueryGroupTags.ts
@@ -13,7 +13,7 @@ export function createQueryGroupTags() {
     return tags.has(tag.key)
   }
 
-  function getTag(tag: QueryTag): Set<number> {
+  function getSubscriptionIdsByTag(tag: QueryTag): Set<number> {
     if(!tags.has(tag.key)) {
       tags.set(tag.key, new Set())
     }
@@ -21,24 +21,24 @@ export function createQueryGroupTags() {
     return tags.get(tag.key)!
   }
 
-  function getSubscription(id: number): Set<QueryTag> {
-    if(!subscriptions.has(id)) {
-      subscriptions.set(id, new Set())
+  function getTagsBySubscriptionId(subscriptionId: number): Set<QueryTag> {
+    if(!subscriptions.has(subscriptionId)) {
+      subscriptions.set(subscriptionId, new Set())
     }
 
-    return subscriptions.get(id)!
+    return subscriptions.get(subscriptionId)!
   }
 
-  function add(tag: QueryTag, id: number): void {
-    getTag(tag).add(id)
-    getSubscription(id).add(tag)
+  function addTag(tag: QueryTag, subscriptionId: number): void {
+    getSubscriptionIdsByTag(tag).add(subscriptionId)
+    getTagsBySubscriptionId(subscriptionId).add(tag)
   }
 
-  function remove(tag: QueryTag, id: number): void {
-    const tagSet = getTag(tag)
-    const subscriptionSet = getSubscription(id)
+  function removeTag(tag: QueryTag, subscriptionId: number): void {
+    const tagSet = getSubscriptionIdsByTag(tag)
+    const subscriptionSet = getTagsBySubscriptionId(subscriptionId)
 
-    tagSet.delete(id)
+    tagSet.delete(subscriptionId)
     subscriptionSet.delete(tag)
 
     if(tagSet.size === 0) {
@@ -46,40 +46,40 @@ export function createQueryGroupTags() {
     }
 
     if(subscriptionSet.size === 0) {
-      subscriptions.delete(id)
+      subscriptions.delete(subscriptionId)
     }
   }
 
-  function addAll(tags: QueryTag[] | undefined, id: number): void {
+  function addAllTags(tags: QueryTag[] | undefined, subscriptionId: number): void {
     if(!tags) {
       return
     }
 
     for(const tag of tags) {
-      add(tag, id)
+      addTag(tag, subscriptionId)
     }
   }
 
-  function removeAll(tags: QueryTag[] | undefined, id: number): void {
+  function removeAllTags(tags: QueryTag[] | undefined, subscriptionId: number): void {
     if(!tags) {
       return
     }
 
     for(const tag of tags) {
-      remove(tag, id)
+      removeTag(tag, subscriptionId)
     }
   }
 
-  function removeAllById(id: number): void {
-    const tags = Array.from(getSubscription(id))
+  function removeAllTagsBySubscriptionId(subscriptionId: number): void {
+    const tags = Array.from(getTagsBySubscriptionId(subscriptionId))
 
-    removeAll(tags, id)
+    removeAllTags(tags, subscriptionId)
   }
 
   return {
     clear,
     has,
-    addAll,
-    removeAllById,
+    addAllTags,
+    removeAllTagsBySubscriptionId,
   }
 }

--- a/src/createQueryGroupTags.ts
+++ b/src/createQueryGroupTags.ts
@@ -1,0 +1,85 @@
+import { QueryTag, QueryTagKey } from "./types/tags"
+
+export function createQueryGroupTags() {
+  const tags = new Map<QueryTagKey, Set<number>>()
+  const subscriptions = new Map<number, Set<QueryTag>>()
+
+  function clear(): void {
+    tags.clear()
+    subscriptions.clear()
+  }
+
+  function has(tag: QueryTag): boolean {
+    return tags.has(tag.key)
+  }
+
+  function getTag(tag: QueryTag): Set<number> {
+    if(!tags.has(tag.key)) {
+      tags.set(tag.key, new Set())
+    }
+
+    return tags.get(tag.key)!
+  }
+
+  function getSubscription(id: number): Set<QueryTag> {
+    if(!subscriptions.has(id)) {
+      subscriptions.set(id, new Set())
+    }
+
+    return subscriptions.get(id)!
+  }
+
+  function add(tag: QueryTag, id: number): void {
+    getTag(tag).add(id)
+    getSubscription(id).add(tag)
+  }
+
+  function remove(tag: QueryTag, id: number): void {
+    const tagSet = getTag(tag)
+    const subscriptionSet = getSubscription(id)
+
+    tagSet.delete(id)
+    subscriptionSet.delete(tag)
+
+    if(tagSet.size === 0) {
+      tags.delete(tag.key)
+    }
+
+    if(subscriptionSet.size === 0) {
+      subscriptions.delete(id)
+    }
+  }
+
+  function addAll(tags: QueryTag[] | undefined, id: number): void {
+    if(!tags) {
+      return
+    }
+
+    for(const tag of tags) {
+      add(tag, id)
+    }
+  }
+
+  function removeAll(tags: QueryTag[] | undefined, id: number): void {
+    if(!tags) {
+      return
+    }
+
+    for(const tag of tags) {
+      remove(tag, id)
+    }
+  }
+
+  function removeAllById(id: number): void {
+    const tags = Array.from(getSubscription(id))
+
+    removeAll(tags, id)
+  }
+
+  return {
+    clear,
+    has,
+    addAll,
+    removeAllById,
+  }
+}


### PR DESCRIPTION
# Description
Adds a new `createQueryGroupTags` factory for storing query tags. This stores tags based based on subscription id in two separate maps so that we can do reverse lookups. This takes up more memory but allows for single operation deletes. 