### PR TITLE
Typed tags

### DIFF
--- a/src/createQueryClient.spec-d.ts
+++ b/src/createQueryClient.spec-d.ts
@@ -1,0 +1,25 @@
+import { describe, test } from "vitest"
+import { createQueryClient } from "./createQueryClient"
+import { tag } from "./tag"
+
+describe('options', () => {
+  test('tags', async () => {
+    const action = () => 'response'
+    const { query } = createQueryClient()
+    const numberTag = tag<number>()
+    const stringTag = tag<string>()
+    const untypedTag = tag()
+
+    // @ts-expect-error
+    query(action, [], { tags: [numberTag, stringTag] })
+
+    // @ts-expect-error
+    query(action, [], { tags: () => [numberTag, stringTag] })
+
+    query(action, [], { tags: [stringTag, untypedTag] })
+    query(action, [], { tags: () => [stringTag, untypedTag] })
+
+    query(action, [], { tags: [untypedTag] })
+    query(action, [], { tags: () => [untypedTag] })
+  })
+})

--- a/src/createQueryGroup.spec.ts
+++ b/src/createQueryGroup.spec.ts
@@ -264,8 +264,8 @@ describe('given group with interval', () => {
 describe('given group with tags', () => {
   test('can check if it has a tag', async () => {
     const group = createQueryGroup(vi.fn(), [])
-    const tag1 = tag('tag1')
-    const tag2 = tag('tag2', (value: string) => value)
+    const tag1 = tag()
+    const tag2 = tag((value: string) => value)
 
     expect(group.hasTag(tag1)).toBe(false)
 

--- a/src/createQueryGroupTags.spec.ts
+++ b/src/createQueryGroupTags.spec.ts
@@ -4,7 +4,7 @@ import { tag } from '@/tag'
 
 test('should add and check tags correctly', () => {
   const tags = createQueryGroupTags()
-  const tag1 = tag('test')
+  const tag1 = tag()
   
   tags.addAllTags([tag1], 1)
 
@@ -13,7 +13,7 @@ test('should add and check tags correctly', () => {
 
 test('should remove tags correctly', () => {
   const tags = createQueryGroupTags()
-  const tag1 = tag('test')
+  const tag1 = tag()
   
   tags.addAllTags([tag1], 1)
   tags.removeAllTagsBySubscriptionId(1)
@@ -23,8 +23,8 @@ test('should remove tags correctly', () => {
 
 test('should handle multiple tags and ids', () => {
   const tags = createQueryGroupTags()
-  const tag1 = tag('test1')
-  const tag2 = tag('test2')
+  const tag1 = tag()
+  const tag2 = tag()
   
   tags.addAllTags([tag1, tag2], 1)
   tags.addAllTags([tag1], 2)
@@ -40,9 +40,9 @@ test('should handle multiple tags and ids', () => {
 
 test('should clear all tags', () => {
   const tags = createQueryGroupTags()
-  const tag1 = tag('test1')
-  const tag2 = tag('test2')
-  const tag3 = tag('test3')
+  const tag1 = tag()
+  const tag2 = tag()
+  const tag3 = tag()
   
   tags.addAllTags([tag1, tag2], 1)
   tags.addAllTags([tag1, tag2, tag3], 2)

--- a/src/tag.spec-d.ts
+++ b/src/tag.spec-d.ts
@@ -31,7 +31,7 @@ test('query from query function with tags are preserved', () => {
   })
 
   type Source = ExtractQueryOptionsFromQuery<typeof value>['tags']
-  type Expected = [QueryTag<'tag1'>, QueryTag<'tag2'>]
+  type Expected = [QueryTag<unknown>, QueryTag<unknown>]
 
   expectTypeOf<Source>().toMatchTypeOf<Expected>()
 })
@@ -109,7 +109,7 @@ test('query from defined query composition with tags are preserved', () => {
   const value = useQuery([])
 
   type Source = ExtractQueryOptionsFromQuery<typeof value>['tags']
-  type Expected = [QueryTag<'tag1'>, QueryTag<'tag2'>]
+  type Expected = [QueryTag<unknown>, QueryTag<unknown>]
 
   expectTypeOf<Source>().toMatchTypeOf<Expected>()
 })

--- a/src/tag.spec-d.ts
+++ b/src/tag.spec-d.ts
@@ -1,7 +1,6 @@
 import { expectTypeOf, test, vi } from "vitest";
 import { QueryTag, QueryTagFactory, Unset } from "@/types/tags";
 import { createQueryClient } from "./createQueryClient";
-import { ExtractQueryOptionsFromQuery } from "./types/query";
 import { tag } from "./tag";
 
 test('tag function returns a tag when no callback is provided', () => {
@@ -36,22 +35,6 @@ test('tag factory returns a typed tag when data generic is provided', () => {
   expectTypeOf(value).toMatchTypeOf<QueryTag<string>>()
 })
 
-test('query from query function with tags are preserved', () => {
-  const { query } = createQueryClient()
-  const action = vi.fn()
-  const tag1 = tag()
-  const tag2 = tag()
-
-  const value = query(action, [], {
-    tags: [tag1, tag2]
-  })
-
-  type Source = ExtractQueryOptionsFromQuery<typeof value>['tags']
-  type Expected = [QueryTag<Unset>, QueryTag<Unset>]
-
-  expectTypeOf<Source>().toMatchTypeOf<Expected>()
-})
-
 test('query from query function with tags callback is called with the query data', () => {
   const { query } = createQueryClient()
   const action = vi.fn(() => 'foo')
@@ -65,22 +48,6 @@ test('query from query function with tags callback is called with the query data
   })
 })
 
-test('query from query composition with tags are preserved', () => {
-  const { useQuery } = createQueryClient()
-  const action = vi.fn()
-  const tag1 = tag()
-  const tag2 = tag()
-
-  const value = useQuery(action, [], {
-    tags: [tag1, tag2]
-  })
-
-  type Source = ExtractQueryOptionsFromQuery<typeof value>['tags']
-  type Expected = [QueryTag<Unset>, QueryTag<Unset>]
-
-  expectTypeOf<Source>().toMatchTypeOf<Expected>()
-})
-
 test('query from query composition with tags callback is called with the query data', () => {
   const { useQuery } = createQueryClient()
   const action = vi.fn(() => 'foo')
@@ -92,40 +59,4 @@ test('query from query composition with tags callback is called with the query d
       return []
     }
   })
-})
-
-test('query from defined query with tags are preserved', () => {
-  const { defineQuery } = createQueryClient()
-  const action = vi.fn()
-  const tag1 = tag()
-  const tag2 = tag()
-
-  const { query } = defineQuery(action, {
-    tags: [tag1, tag2]
-  })
-
-  const value = query([])
-
-  type Source = ExtractQueryOptionsFromQuery<typeof value>['tags']
-  type Expected = [QueryTag<Unset>, QueryTag<Unset>]
-
-  expectTypeOf<Source>().toMatchTypeOf<Expected>()
-})
-
-test('query from defined query composition with tags are preserved', () => {
-  const { defineQuery } = createQueryClient()
-  const action = vi.fn()
-  const tag1 = tag()
-  const tag2 = tag()
-
-  const { useQuery } = defineQuery(action, {
-    tags: [tag1, tag2]
-  })
-
-  const value = useQuery([])
-
-  type Source = ExtractQueryOptionsFromQuery<typeof value>['tags']
-  type Expected = [QueryTag<Unset>, QueryTag<Unset>]
-
-  expectTypeOf<Source>().toMatchTypeOf<Expected>()
 })

--- a/src/tag.spec-d.ts
+++ b/src/tag.spec-d.ts
@@ -1,5 +1,5 @@
 import { expectTypeOf, test, vi } from "vitest";
-import { QueryTag, QueryTagFactory } from "@/types/tags";
+import { QueryTag, QueryTagFactory, Unset } from "@/types/tags";
 import { createQueryClient } from "./createQueryClient";
 import { ExtractQueryOptionsFromQuery } from "./types/query";
 import { tag } from "./tag";
@@ -17,7 +17,23 @@ test('tag function returns a tag factory when a callback is provided', () => {
 
   const value = factory('foo')
 
-  expectTypeOf(value).toMatchTypeOf<QueryTag<unknown>>()
+  expectTypeOf(value).toMatchTypeOf<QueryTag<Unset>>()
+})
+
+test('tag function returns a typed tag when data generic is provided', () => {
+  const value = tag<string>()
+
+  expectTypeOf(value).toMatchTypeOf<QueryTag<string>>()
+})
+
+test('tag factory returns a typed tag when data generic is provided', () => {
+  const factory = tag<string, string>((value: string) => value)
+
+  expectTypeOf(factory).toMatchTypeOf<QueryTagFactory<string, string>>()
+
+  const value = factory('foo')
+
+  expectTypeOf(value).toMatchTypeOf<QueryTag<string>>()
 })
 
 test('query from query function with tags are preserved', () => {
@@ -31,7 +47,7 @@ test('query from query function with tags are preserved', () => {
   })
 
   type Source = ExtractQueryOptionsFromQuery<typeof value>['tags']
-  type Expected = [QueryTag<unknown>, QueryTag<unknown>]
+  type Expected = [QueryTag<Unset>, QueryTag<Unset>]
 
   expectTypeOf<Source>().toMatchTypeOf<Expected>()
 })
@@ -60,7 +76,7 @@ test('query from query composition with tags are preserved', () => {
   })
 
   type Source = ExtractQueryOptionsFromQuery<typeof value>['tags']
-  type Expected = [QueryTag<unknown>, QueryTag<unknown>]
+  type Expected = [QueryTag<Unset>, QueryTag<Unset>]
 
   expectTypeOf<Source>().toMatchTypeOf<Expected>()
 })
@@ -91,7 +107,7 @@ test('query from defined query with tags are preserved', () => {
   const value = query([])
 
   type Source = ExtractQueryOptionsFromQuery<typeof value>['tags']
-  type Expected = [QueryTag<unknown>, QueryTag<unknown>]
+  type Expected = [QueryTag<Unset>, QueryTag<Unset>]
 
   expectTypeOf<Source>().toMatchTypeOf<Expected>()
 })
@@ -109,7 +125,7 @@ test('query from defined query composition with tags are preserved', () => {
   const value = useQuery([])
 
   type Source = ExtractQueryOptionsFromQuery<typeof value>['tags']
-  type Expected = [QueryTag<unknown>, QueryTag<unknown>]
+  type Expected = [QueryTag<Unset>, QueryTag<Unset>]
 
   expectTypeOf<Source>().toMatchTypeOf<Expected>()
 })

--- a/src/tag.spec-d.ts
+++ b/src/tag.spec-d.ts
@@ -5,26 +5,26 @@ import { ExtractQueryOptionsFromQuery } from "./types/query";
 import { tag } from "./tag";
 
 test('tag function returns a tag when no callback is provided', () => {
-  const value = tag('test')
+  const value = tag()
 
-  expectTypeOf(value).toMatchTypeOf<QueryTag<'test'>>()  
+  expectTypeOf(value).toMatchTypeOf<QueryTag>()  
 })
 
 test('tag function returns a tag factory when a callback is provided', () => {
-  const factory = tag('test', (string: string) => string)
+  const factory = tag((string: string) => string)
 
-  expectTypeOf(factory).toMatchTypeOf<QueryTagFactory<'test',string>>()
+  expectTypeOf(factory).toMatchTypeOf<QueryTagFactory<unknown, string>>()
 
   const value = factory('foo')
 
-  expectTypeOf(value).toMatchTypeOf<QueryTag<'test'>>()
+  expectTypeOf(value).toMatchTypeOf<QueryTag<unknown>>()
 })
 
 test('query from query function with tags are preserved', () => {
   const { query } = createQueryClient()
   const action = vi.fn()
-  const tag1 = tag('tag1')
-  const tag2 = tag('tag2')
+  const tag1 = tag()
+  const tag2 = tag()
 
   const value = query(action, [], {
     tags: [tag1, tag2]
@@ -52,15 +52,15 @@ test('query from query function with tags callback is called with the query data
 test('query from query composition with tags are preserved', () => {
   const { useQuery } = createQueryClient()
   const action = vi.fn()
-  const tag1 = tag('tag1')
-  const tag2 = tag('tag2')
+  const tag1 = tag()
+  const tag2 = tag()
 
   const value = useQuery(action, [], {
     tags: [tag1, tag2]
   })
 
   type Source = ExtractQueryOptionsFromQuery<typeof value>['tags']
-  type Expected = [QueryTag<'tag1'>, QueryTag<'tag2'>]
+  type Expected = [QueryTag<unknown>, QueryTag<unknown>]
 
   expectTypeOf<Source>().toMatchTypeOf<Expected>()
 })
@@ -81,8 +81,8 @@ test('query from query composition with tags callback is called with the query d
 test('query from defined query with tags are preserved', () => {
   const { defineQuery } = createQueryClient()
   const action = vi.fn()
-  const tag1 = tag('tag1')
-  const tag2 = tag('tag2')
+  const tag1 = tag()
+  const tag2 = tag()
 
   const { query } = defineQuery(action, {
     tags: [tag1, tag2]
@@ -91,7 +91,7 @@ test('query from defined query with tags are preserved', () => {
   const value = query([])
 
   type Source = ExtractQueryOptionsFromQuery<typeof value>['tags']
-  type Expected = [QueryTag<'tag1'>, QueryTag<'tag2'>]
+  type Expected = [QueryTag<unknown>, QueryTag<unknown>]
 
   expectTypeOf<Source>().toMatchTypeOf<Expected>()
 })
@@ -99,8 +99,8 @@ test('query from defined query with tags are preserved', () => {
 test('query from defined query composition with tags are preserved', () => {
   const { defineQuery } = createQueryClient()
   const action = vi.fn()
-  const tag1 = tag('tag1')
-  const tag2 = tag('tag2')
+  const tag1 = tag()
+  const tag2 = tag()
 
   const { useQuery } = defineQuery(action, {
     tags: [tag1, tag2]

--- a/src/tag.spec.ts
+++ b/src/tag.spec.ts
@@ -2,15 +2,15 @@ import { expect, test } from "vitest";
 import { tag } from "./tag";
 
 test('tags are unique', () => {
-  const tag1 = tag('test')
-  const tag2 = tag('test')
+  const tag1 = tag()
+  const tag2 = tag()
 
   expect(tag1).not.toBe(tag2)
 })
 
 test('tag factories are unique', () => {
-  const factory1 = tag('test', (string: string) => string)
-  const factory2 = tag('test', (string: string) => string)
+  const factory1 = tag((string: string) => string)
+  const factory2 = tag((string: string) => string)
   const value1 = factory1('foo')
   const value2 = factory2('foo')
 
@@ -18,7 +18,7 @@ test('tag factories are unique', () => {
 })
 
 test('tag factory returns the same key when given the same value', () => {
-  const factory = tag('test', (string: string) => string)
+  const factory = tag((string: string) => string)
   const value1 = factory('foo')
   const value2 = factory('foo')
 

--- a/src/tag.ts
+++ b/src/tag.ts
@@ -1,16 +1,17 @@
 import { createSequence } from "./createSequence";
-import { QueryTagFactory, QueryTagCallback, QueryTag } from "./types/tags";
+import { QueryTagFactory, QueryTagCallback, QueryTag, Unset, unset } from "./types/tags";
 
 function createQueryTag(id: number, value: unknown): QueryTag {
   return {
+    data: unset,
     key: `${id}-${JSON.stringify(value)}`
   }
 }
 
 const getId = createSequence()
 
-export function tag<const TData>(): QueryTag<TData>
-export function tag<const TData, TInput>(callback: QueryTagCallback<TInput>): QueryTagFactory<TData, TInput>
+export function tag<const TData = Unset>(): QueryTag<TData>
+export function tag<const TData = Unset, TInput = unknown>(callback: QueryTagCallback<TInput>): QueryTagFactory<TData, TInput>
 export function tag(callback?: QueryTagCallback): QueryTag | QueryTagFactory {
   const id = getId();
 

--- a/src/tag.ts
+++ b/src/tag.ts
@@ -1,23 +1,22 @@
 import { createSequence } from "./createSequence";
 import { QueryTagFactory, QueryTagCallback, QueryTag } from "./types/tags";
 
-function createQueryTag(id: number, name: string, value: unknown): QueryTag {
+function createQueryTag(id: number, value: unknown): QueryTag {
   return {
-    name,
     key: `${id}-${JSON.stringify(value)}`
   }
 }
 
 const getId = createSequence()
 
-export function tag<const TName extends string>(name: TName): QueryTag<TName>
-export function tag<const TName extends string, TInput>(name: TName, callback: QueryTagCallback<TInput>): QueryTagFactory<TName, TInput>
-export function tag(name: string, callback?: QueryTagCallback): QueryTag | QueryTagFactory {
+export function tag<const TData>(): QueryTag<TData>
+export function tag<const TData, TInput>(callback: QueryTagCallback<TInput>): QueryTagFactory<TData, TInput>
+export function tag(callback?: QueryTagCallback): QueryTag | QueryTagFactory {
   const id = getId();
 
   if (callback) {
-    return (value) => createQueryTag(id, name, callback(value))
+    return (value) => createQueryTag(id, callback(value))
   }
 
-  return createQueryTag(id, name, undefined)
+  return createQueryTag(id, undefined)
 }

--- a/src/types/query.ts
+++ b/src/types/query.ts
@@ -23,10 +23,6 @@ export type QueryOptions<
   retries?: number | Partial<RetryOptions>,
 }
 
-export type ExtractQueryOptionsFromQuery<
-  TQuery extends Query<any, any>
-> = TQuery extends Query<any, infer TOptions> ? TOptions : never
-
 export type Query<
   TAction extends QueryAction,
   TOptions extends QueryOptions<TAction>

--- a/src/types/query.ts
+++ b/src/types/query.ts
@@ -1,12 +1,16 @@
 import { RetryOptions } from "@/utilities/retry";
 import { Getter, MaybeGetter } from "./getters";
-import { QueryTag } from "@/types/tags";
+import { QueryTag, Unset } from "@/types/tags";
 
 export type QueryAction = (...args: any[]) => any
 
 export type QueryActionArgs<
   TAction extends QueryAction
 > = MaybeGetter<Parameters<TAction>> | Getter<Parameters<TAction> | null> | Getter<null>
+
+export type QueryTags<
+  TAction extends QueryAction,
+> = QueryTag<Awaited<ReturnType<TAction>> | Unset>[] | ((value: Awaited<ReturnType<TAction>>) => QueryTag<Awaited<ReturnType<TAction>> | Unset>[])
 
 export type QueryOptions<
   TAction extends QueryAction,
@@ -15,7 +19,7 @@ export type QueryOptions<
   interval?: number,
   onSuccess?: (value: Awaited<ReturnType<TAction>>) => void,
   onError?: (error: unknown) => void,
-  tags?: QueryTag[] | ((value: Awaited<ReturnType<TAction>>) => QueryTag[])
+  tags?: QueryTags<TAction>,
   retries?: number | Partial<RetryOptions>,
 }
 

--- a/src/types/tags.ts
+++ b/src/types/tags.ts
@@ -1,6 +1,15 @@
+export const unset = Symbol('unset')
+export type Unset = typeof unset
+
 export type QueryTag<
- TData = unknown,
+ TData extends unknown = Unset,
 > = {
+  /**
+   * @private
+   * @internal
+   * This property is unused, but necessary to preserve the type for TData because unused generics are ignored by typescript.
+   */
+  data: TData,
   key: QueryTagKey
 }
 

--- a/src/types/tags.ts
+++ b/src/types/tags.ts
@@ -1,7 +1,6 @@
 export type QueryTag<
- TName extends string = string,
+ TData = unknown,
 > = {
-  name: TName,
   key: QueryTagKey
 }
 
@@ -17,7 +16,7 @@ export type QueryTagCallback<
 > = (input: TInput) => any
 
 export type QueryTagFactory<
-  TName extends string = string,
+  TData = unknown,
   TInput = unknown,
-> = (value: TInput) => QueryTag<TName>
+> = (value: TInput) => QueryTag<TData>
 


### PR DESCRIPTION
# Description
Reworks tags to make them a driver of types across queries and mutations. 

## Motivation
Tags are a method of organization and retrieval for queries. But without type safety we can never have a 100% type safe means of getting or updating a query based on its tags.

## Solution
Originally I had in mind that tag names would be a means of making tags type safe across queries and other features by somehow "registering" or associating tags with queries and doing some sort of reverse lookup to get the data type for a query based on its tag. 

This solution makes tags themselves typed. This makes types much simpler, more intuitive, and also much stricter/safer from a type perspective. 

## Implementation
Tags no longer require a name be passed when being created. This simplifies tag creation.
```ts
// simple tag
const users = tag()
// tag factory
const user = tag((userId: string) => userId)
```

Tags can now be passed a type as the first generic to create a "typed tag"
```ts
// simple tag
const users = tag<User | User[]>()
// tag factory
const user = tag<User>((userId: string) => userId)
```

When adding tags to a query, the query will enforce that its tags are either untyped or that any typed tags match the data type for the query.
```ts
const untyped = tag()
const string = tag<string>()
const number = tag<number>()

// no type error
query(() => 'hello world', [], {
  tags: [untyped, string]
})

// type error
query(() => 'hello world', [], {
  tags: [number]
})
```

This will allow for future features and syntaxes where given a tag the types for any queries associated with that tag can be known. Such as these 
```ts
const number = tag<number>()
const string = tag<string>()

const { mutate } = useMutation(action, [number, string], {
  onMutate: (queries) => {
    queries.forEach(query => {
      query.data // type number | string
    })
  })
})

setQueryData(number, (queries) => {
  // all queries have a data type of `number`
})
```
None of these examples are real but will be possible because of typed tags. 