### PR TITLE
QueryGroups cleanup after dispose (via AbortController)

### DIFF
--- a/src/createQueryGroup.ts
+++ b/src/createQueryGroup.ts
@@ -121,11 +121,15 @@ export function createQueryGroup<
     tags.addAllTags(tagsToAdd, id)
   }
 
+  function isActive(): boolean {
+    return subscriptions.size > 0
+  }
+
   function removeSubscription(subscriptionId: number): void {
     tags.removeAllTagsBySubscriptionId(subscriptionId)
     subscriptions.delete(subscriptionId)
 
-    if(subscriptions.size === 0) {
+    if(!isActive()) {
       abortController.abort()
     }
   }
@@ -231,7 +235,7 @@ export function createQueryGroup<
     execute,
     abortSignal: abortController.signal,
     get active() {
-      return subscriptions.size > 0
+      return isActive()
     },
   }
 }

--- a/src/createQueryGroups.spec.ts
+++ b/src/createQueryGroups.spec.ts
@@ -1,10 +1,19 @@
-import { test, expect, vi } from "vitest"
+import { test, expect, vi, afterEach, beforeEach } from "vitest"
 import { createQueryGroups } from "./createQueryGroups"
 import * as CreateQueryGroupExports from './createQueryGroup'
 import { QueryAction } from "./types/query"
 
 const getRandomNumber = () => Math.random()
 const multipleByTwo = (value: number) => value * 2
+
+beforeEach(() => {
+  vi.resetModules()
+  vi.clearAllMocks()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
 
 test('whenever createQuery is called with a new action, it should create a group', () => {
   const createQueryGroup = vi.spyOn(CreateQueryGroupExports, 'createQueryGroup')
@@ -54,6 +63,7 @@ test('when createQuery is called, it should pass options through to the group', 
   vi.spyOn(CreateQueryGroupExports, 'createQueryGroup').mockReturnValue({
     subscribe,
     active: true,
+    abortSignal: new AbortController().signal,
     hasTag: vi.fn(),
     execute: vi.fn(),
   })
@@ -68,4 +78,15 @@ test('when createQuery is called, it should pass options through to the group', 
 
   expect(subscribe).toHaveBeenCalledOnce()
   expect(subscribe).toHaveBeenCalledWith(options)
+})
+
+test('disposing of all queries should delete the group', () => {
+  const { createQuery, hasQueryGroup } = createQueryGroups()
+  const query = createQuery(getRandomNumber, [])
+
+  expect(hasQueryGroup(getRandomNumber, [])).toBe(true)
+
+  query.dispose()
+
+  expect(hasQueryGroup(getRandomNumber, [])).toBe(false)
 })

--- a/src/createQueryGroups.ts
+++ b/src/createQueryGroups.ts
@@ -34,10 +34,22 @@ export function createQueryGroups(options?: QueryGroupOptions) {
     const queryKey = createGroupKey(action, parameters)
 
     if(!groups.has(queryKey)) {
-      groups.set(queryKey, createQueryGroup(action, parameters, options))
+      const group = createQueryGroup(action, parameters, options)
+
+      group.abortSignal.addEventListener('abort', () => {
+        groups.delete(queryKey)
+      })
+
+      groups.set(queryKey, group)
     }
 
     return groups.get(queryKey)!
+  }
+
+  function hasQueryGroup(action: QueryAction, parameters: Parameters<QueryAction>): boolean {
+    const queryKey = createGroupKey(action, parameters)
+
+    return groups.has(queryKey)
   }
 
   const createQuery: CreateQuery = (action, parameters, options) => {
@@ -48,5 +60,6 @@ export function createQueryGroups(options?: QueryGroupOptions) {
 
   return {
     createQuery,
+    hasQueryGroup,
   }
 }


### PR DESCRIPTION
## What

When the first query for a given action + args is requested, `createQueryGroup` is called, the new group is added to a map, and that entry is never deleted. My expectation is that when all queries have been disposed, the group should delete the group itself. 

## Why

The group is what holds the reference to things like `data` so I'd expect this cleanup to actually be quite important for heap size over time. Also, considering the implementation of `ttl` if the group is never actually removed the concept of `ttl` seems irrelevant.

## How

I added an abort controller to each QueryGroup. Currently whenever a subscription is disposed, the group cleans up it's own maps for subscriptions and tags. This process now also checks to see if the group is "inactive", in which case it triggers the `abortController.abort()`. This signals to the parent context that the group is ready to be cleaned up.

The thought is that in the future when we implement `ttl`, this process will delay the abort() by however many milliseconds are in the options.