### PR TITLE
QueryGroups cleanup after dispose (via onDispose callback)

### DIFF
--- a/src/createQueryClient.spec.ts
+++ b/src/createQueryClient.spec.ts
@@ -140,6 +140,20 @@ describe('query', () => {
     expect(onError).toHaveBeenCalledOnce()
   })
 
+  test('onDispose', async () => {
+    const action = vi.fn()
+    const onDispose = vi.fn()
+    const { query } = createQueryClient()
+
+    const {dispose} = query(action, [], { onDispose })
+
+    await vi.runOnlyPendingTimersAsync()
+
+    dispose()
+
+    expect(onDispose).toHaveBeenCalledOnce()
+  })
+
   test('placeholder', async () => {
     const placeholder = Symbol('placeholder')
     const response = Symbol('response')

--- a/src/createQueryGroups.spec.ts
+++ b/src/createQueryGroups.spec.ts
@@ -167,17 +167,15 @@ describe('getQueryGroups', () => {
     
     expect(groups.length).toBe(3)
   })
-})
 
-describe('hasQueryGroup', () => {
-  test('returns false after disposing of all queries', () => {
-    const { createQuery, hasQueryGroup } = createQueryGroups()
+  test('disposing of all queries for a group, removes a previously created group', () => {
+    const { createQuery, getQueryGroups } = createQueryGroups()
     const query = createQuery(getRandomNumber, [])
   
-    expect(hasQueryGroup(getRandomNumber, [])).toBe(true)
+    expect(getQueryGroups(getRandomNumber, [])).toHaveLength(1)
   
     query.dispose()
   
-    expect(hasQueryGroup(getRandomNumber, [])).toBe(false)
+    expect(getQueryGroups(getRandomNumber, [])).toHaveLength(0)
   })
 })

--- a/src/createQueryGroups.spec.ts
+++ b/src/createQueryGroups.spec.ts
@@ -168,3 +168,16 @@ describe('getQueryGroups', () => {
     expect(groups.length).toBe(3)
   })
 })
+
+describe('hasQueryGroup', () => {
+  test('returns false after disposing of all queries', () => {
+    const { createQuery, hasQueryGroup } = createQueryGroups()
+    const query = createQuery(getRandomNumber, [])
+  
+    expect(hasQueryGroup(getRandomNumber, [])).toBe(true)
+  
+    query.dispose()
+  
+    expect(hasQueryGroup(getRandomNumber, [])).toBe(false)
+  })
+})

--- a/src/createQueryGroups.ts
+++ b/src/createQueryGroups.ts
@@ -19,17 +19,9 @@ export type GetQueryGroups = {
   <TAction extends QueryAction>(action: TAction, parameters: Parameters<TAction>): QueryGroup[]
 }
 
-export type HasQueryGroup = {
-  <TQueryTag extends QueryTag>(tag: TQueryTag): boolean
-  <TQueryTag extends QueryTag>(tags: TQueryTag[]): boolean
-  <TAction extends QueryAction>(action: TAction): boolean
-  <TAction extends QueryAction>(action: TAction, parameters: Parameters<TAction>): boolean
-}
-
 export type CreateQueryGroups = {
   createQuery: CreateQuery
   getQueryGroups: GetQueryGroups
-  hasQueryGroup: HasQueryGroup
 }
 
 export function createQueryGroups(options?: QueryGroupOptions) {
@@ -111,18 +103,8 @@ export function createQueryGroups(options?: QueryGroupOptions) {
     assertNever(tagOrAction, 'Invalid arguments given to setQueryData')
   }
 
-  function hasQueryGroup (
-    tagOrAction: QueryTag | QueryTag[] | QueryAction,
-    parameters?:  Parameters<QueryAction>,
-  ): boolean {
-    const groups = getQueryGroups(tagOrAction, parameters)
-
-    return groups.length > 0
-  }
-
   return {
     createQuery,
     getQueryGroups,
-    hasQueryGroup,
   }
 }

--- a/src/types/query.ts
+++ b/src/types/query.ts
@@ -25,6 +25,7 @@ export type QueryOptions<
   interval?: number,
   onSuccess?: (value: QueryData<TAction>) => void,
   onError?: (error: unknown) => void,
+  onDispose?: () => void,
   tags?: QueryTags<TAction>,
   retries?: number | Partial<RetryOptions>,
 }


### PR DESCRIPTION
this is a take 2 of the same idea proposed [here](https://github.com/kitbagjs/query/pull/25). This version uses an `onDispose` callback (like onSuccess, onError) to check if group is no longer active.

## What

When the first query for a given action + args is requested, `createQueryGroup` is called, the new group is added to a map, and that entry is never deleted. My expectation is that when all queries have been disposed, the group should delete the group itself. 

## Why

The group is what holds the reference to things like `data` so I'd expect this cleanup to actually be quite important for heap size over time. Also, considering the implementation of `ttl` if the group is never actually removed the concept of `ttl` seems irrelevant.

## How

- I added support for `onDispose` to subscription options
- I added the ability to pass subscription options at the group level, which get spread as defaults
- I always supply an `onDispose` from createQueryGroups service, which checks if the group is no longer active - cleans it up if it's not.
- I added `hasQueryGroup` to public API for createQueryGroups, extends the `getQueryGroups` method, currently only used in test to prove that cleanup happened but totally optional

The thought is that in the future when we implement `ttl`, this process will delay the abort() by however many milliseconds are in the options.