### PR TITLE
onDispose callback for QueryGroup, cleanup groups set when last subscription is dipsosed

### DIFF
--- a/src/createQueryGroup.spec.ts
+++ b/src/createQueryGroup.spec.ts
@@ -124,32 +124,6 @@ describe('when action throws an error', () => {
   })
 })
 
-test('active property is true whenever there are 1+ query', async () => {
-  const response = Symbol('response')
-  const action = vi.fn(() => response)
-  const group = createQueryGroup(action, [])
-
-  const first = group.createQuery()
-
-  await vi.runOnlyPendingTimersAsync()
-
-  expect(group.active).toBe(true)
-  
-  const second = group.createQuery()
-
-  await vi.runOnlyPendingTimersAsync()
-
-  expect(group.active).toBe(true)
-
-  first.dispose()
-
-  expect(group.active).toBe(true)
-
-  second.dispose()
-
-  expect(group.active).toBe(false)
-})
-
 describe('given group with interval', () => {
   test('with single interval of 5, runs every 5ms', async () => {
     const response = Symbol('response')

--- a/src/createQueryGroups.spec.ts
+++ b/src/createQueryGroups.spec.ts
@@ -65,7 +65,6 @@ describe('createQuery', () => {
 
     vi.spyOn(CreateQueryGroupExports, 'createQueryGroup').mockReturnValue({
       createQuery: mock,
-      active: true,
       hasTag: vi.fn(),
       execute: vi.fn(),
     })
@@ -166,5 +165,16 @@ describe('getQueryGroups', () => {
     const groups = getQueryGroups([tag1, tag2])
     
     expect(groups.length).toBe(3)
+  })
+
+  test('disposing of all queries for a group, removes a previously created group', () => {
+    const { createQuery, getQueryGroups } = createQueryGroups()
+    const query = createQuery(getRandomNumber, [])
+
+    expect(getQueryGroups(getRandomNumber, [])).toHaveLength(1)
+
+    query.dispose()
+
+    expect(getQueryGroups(getRandomNumber, [])).toHaveLength(0)
   })
 })

--- a/src/createQueryGroups.ts
+++ b/src/createQueryGroups.ts
@@ -55,7 +55,13 @@ export function createQueryGroups(options?: QueryGroupOptions) {
     actionGroups.get(actionKey)!.add(groupKey)
 
     if(!groups.has(groupKey)) {
-      groups.set(groupKey, createQueryGroup(action, parameters, options))
+      const onDispose = () => {
+        groups.delete(groupKey)
+      }
+
+      const group = createQueryGroup(action, parameters, {...options, onDispose})
+
+      groups.set(groupKey, group)
     }
 
     return groups.get(groupKey)!


### PR DESCRIPTION
## What

When the first query for a given action + args is requested, `createQueryGroup` is called, the new group is added to a map, and that entry is never deleted. My expectation is that when all queries have been disposed, the group should delete the group itself. 

## Why

The group is what holds the reference to things like `data` so I'd expect this cleanup to actually be quite important for heap size over time. Also, considering the implementation of `ttl` if the group is never actually removed the concept of `ttl` seems irrelevant.

## How

- Adds `onDispose` callback option to `createQueryGroup`
- Using that callback to cleanup groups set after last subscription is disposed

The thought is that in the future when we implement `ttl`, this process will delay the abort() by however many milliseconds are in the options.