### PR TITLE
Add `setQueryData` utility to the client

### DIFF
--- a/src/createQueryClient.spec-d.ts
+++ b/src/createQueryClient.spec-d.ts
@@ -1,4 +1,4 @@
-import { describe, expect, expectTypeOf, test } from "vitest"
+import { describe, expectTypeOf, test } from "vitest"
 import { createQueryClient } from "./createQueryClient"
 import { tag } from "./tag"
 

--- a/src/createQueryClient.spec-d.ts
+++ b/src/createQueryClient.spec-d.ts
@@ -1,4 +1,4 @@
-import { describe, test } from "vitest"
+import { describe, expect, expectTypeOf, test } from "vitest"
 import { createQueryClient } from "./createQueryClient"
 import { tag } from "./tag"
 
@@ -21,5 +21,109 @@ describe('options', () => {
 
     query(action, [], { tags: [untypedTag] })
     query(action, [], { tags: () => [untypedTag] })
+  })
+})
+
+describe('setQueryData', () => {
+  test('tags', async () => {
+    const { setQueryData } = createQueryClient()
+    const numberTag = tag<number>()
+    const stringTag = tag<string>()
+    const untypedTag = tag()
+
+    setQueryData(untypedTag, (data) => {
+      expectTypeOf(data).toMatchTypeOf<unknown>()
+      return 'foo'
+    })
+
+    setQueryData(numberTag, (data) => {
+      expectTypeOf(data).toMatchTypeOf<number>()
+      return 2
+    })
+
+    setQueryData(stringTag, (data) => {
+      expectTypeOf(data).toMatchTypeOf<string>()
+      return 'new string'
+    })
+
+    setQueryData([untypedTag], (data) => {
+      expectTypeOf(data).toMatchTypeOf<unknown>()
+      return 'foo'
+    })
+
+    setQueryData([numberTag], (data) => {
+      expectTypeOf(data).toMatchTypeOf<number>()
+      return 2
+    })
+
+    // this is kinda interesting, no matter the data the return type is the union :thinking:
+    // so there's not really a type safe way to update multiple queries at once
+    setQueryData([numberTag, stringTag], (data) => {
+      expectTypeOf(data).toMatchTypeOf<number | string>()
+      return 'foo'
+    })
+
+    setQueryData([untypedTag, stringTag, numberTag], (data) => {
+      expectTypeOf(data).toMatchTypeOf<unknown>()
+      return 'foo'
+    })
+
+    // @ts-expect-error
+    setQueryData(numberTag, (data) => {
+      expectTypeOf(data).toMatchTypeOf<number>()
+      return 'string'
+    })
+
+    // @ts-expect-error
+    setQueryData([numberTag, stringTag], (data) => {
+      expectTypeOf(data).toMatchTypeOf<number | string>()
+      return []
+    })
+  })
+
+  test('actions', () => {
+    const { setQueryData } = createQueryClient()
+
+    const stringAction = () => 'foo'
+    const numberAction = () => 2
+
+    setQueryData(stringAction, (data) => {
+      expectTypeOf(data).toMatchTypeOf<string>()
+      return 'bar'
+    })
+
+    setQueryData(numberAction, (data) => {
+      expectTypeOf(data).toMatchTypeOf<number>()
+      return 3
+    })
+
+    // @ts-expect-error
+    setQueryData(stringAction, (data) => {
+      expectTypeOf(data).toMatchTypeOf<string>()
+      return 3
+    })
+  })
+
+  test('actions with parameters', () => {
+    const { setQueryData } = createQueryClient()
+
+    const stringAction = (param: string) => param
+    const numberAction = (param: number) => param
+
+    setQueryData(stringAction, ['foo'], (data) => {
+      expectTypeOf(data).toMatchTypeOf<string>()
+      return 'bar'
+    })
+
+    setQueryData(numberAction, [2], (data) => {
+      expectTypeOf(data).toMatchTypeOf<number>()
+      return 3
+    })
+
+    // @ts-expect-error
+    setQueryData(stringAction, ['foo'], (data) => {
+      expectTypeOf(data).toMatchTypeOf<string>()
+      return 3
+    })
   })
 })

--- a/src/createQueryClient.spec.ts
+++ b/src/createQueryClient.spec.ts
@@ -2,6 +2,7 @@ import { test, expect, vi, describe, afterEach, beforeEach } from 'vitest'
 import { createQueryClient } from './createQueryClient'
 import { effectScope, ref } from 'vue'
 import { timeout } from './utilities/timeout'
+import { tag } from './tag'
 
 beforeEach(() => {
   vi.useFakeTimers()
@@ -508,5 +509,107 @@ describe('options', () => {
     expect(result.error).toBeDefined()
     expect(result.errored).toBe(true)
     expect(result.executed).toBe(true)
+  })
+})
+
+describe('setQueryData', () => {
+  test('tag', async () => {
+    const { setQueryData, query } = createQueryClient()
+    const stringTag = tag<string>()
+    const numberTag = tag<number>()
+
+    const stringAction = () => 'foo'
+    const numberAction = () => 1
+
+    const stringQuery = query(stringAction, [], { tags: [stringTag] })
+    const numberQuery = query(numberAction, [], { tags: [numberTag] })
+
+    await vi.runOnlyPendingTimersAsync()
+
+    setQueryData(stringTag, () => {
+      return 'bar'
+    })
+
+    setQueryData(numberTag, () => {
+      return 2
+    })
+
+    expect(stringQuery.data).toBe('bar')
+    expect(numberQuery.data).toBe(2)
+  })
+
+  test('tags', async () => {
+    const { setQueryData, query } = createQueryClient()
+    const stringTag = tag<string>()
+    const numberTag = tag<number>()
+
+    const stringAction = () => 'foo'
+    const numberAction = () => 1
+
+    const stringQuery = query(stringAction, [], { tags: [stringTag] })
+    const numberQuery = query(numberAction, [], { tags: [numberTag] })
+
+    await vi.runOnlyPendingTimersAsync()
+
+    setQueryData([stringTag], () => {
+      return 'bar'
+    })
+
+    setQueryData([numberTag], () => {
+      return 2
+    })
+
+    expect(stringQuery.data).toBe('bar')
+    expect(numberQuery.data).toBe(2)
+  })
+
+  test('action', async () => {
+    const { setQueryData, query } = createQueryClient()
+
+    const stringAction = () => 'foo'
+    const numberAction = () => 1
+
+    const stringQuery = query(stringAction, [])
+    const numberQuery = query(numberAction, [])
+
+    await vi.runOnlyPendingTimersAsync()
+
+    setQueryData(stringAction, () => {
+      return 'bar'
+    })
+
+    setQueryData(numberAction, () => {
+      return 2
+    })
+
+    expect(stringQuery.data).toBe('bar')
+    expect(numberQuery.data).toBe(2)
+  })
+
+  test('action with parameters', async () => {
+    const { setQueryData, query } = createQueryClient()
+
+    const stringAction = (param: string) => param
+    const numberAction = (param: number) => param
+
+    const stringQuery = query(stringAction, ['foo'])
+    const stringQuery2 = query(stringAction, ['bar'])
+    const numberQuery = query(numberAction, [1])
+    const numberQuery2 = query(numberAction, [2])
+
+    await vi.runOnlyPendingTimersAsync()
+
+    setQueryData(stringAction, ['foo'], () => {
+      return 'baz'
+    })
+
+    setQueryData(numberAction, [1], () => {
+      return 3
+    })
+
+    expect(stringQuery.data).toBe('baz')
+    expect(numberQuery.data).toBe(3)
+    expect(stringQuery2.data).toBe('bar')
+    expect(numberQuery2.data).toBe(2)
   })
 })

--- a/src/createQueryClient.ts
+++ b/src/createQueryClient.ts
@@ -1,4 +1,4 @@
-import { QueryAction, QueryOptions } from "./types/query";
+import { isQueryAction, QueryAction, QueryOptions } from "./types/query";
 import { ClientOptions } from "./types/clientOptions";
 import { 
   DefinedQueryComposition,
@@ -6,13 +6,20 @@ import {
   DefineQuery,
   QueryClient,
   QueryComposition,
+  QueryDataSetter,
   QueryFunction,
+  SetQueryData,
 } from "./types/client";
 import { createQueryGroups } from "./createQueryGroups";
 import { createUseQuery } from "./createUseQuery";
+import { isQueryTag, isQueryTags, QueryTag } from "./types/tags";
+import { isArray } from "./utilities/arrays";
+import { F } from "vitest/dist/chunks/reporters.QZ837uWx.js";
+import { assertNever } from "./utilities/assert";
+import { QueryGroup } from "./createQueryGroup";
 
 export function createQueryClient(options?: ClientOptions): QueryClient {
-  const { createQuery } = createQueryGroups(options)
+  const { createQuery, getQueryGroups } = createQueryGroups(options)
 
   const query: QueryFunction = (action, args, options) => {
     return createQuery(action, args, options)
@@ -40,9 +47,68 @@ export function createQueryClient(options?: ClientOptions): QueryClient {
     }
   }
 
+  const setQueryData: SetQueryData = (
+    param1: QueryTag | QueryTag[] | QueryAction, 
+    param2: Parameters<QueryAction> | QueryDataSetter, 
+    param3?: QueryDataSetter
+  ) => {
+    const setDataForGroups = (groups: QueryGroup[], setter: QueryDataSetter) => {
+      groups.forEach(group => {
+        const data = group.getData()
+        const newData = setter(data)
+        
+        group.setData(newData)
+      })
+    }
+
+    if(isQueryTag(param1)) {
+      const tag = param1
+      const setter = param2 as QueryDataSetter
+      const groups = getQueryGroups(tag)
+
+      setDataForGroups(groups, setter)
+
+      return
+    }
+
+    if(isQueryTags(param1)) {
+      const tags = param1
+      const setter = param2 as QueryDataSetter
+      const groups = getQueryGroups(tags)
+
+      setDataForGroups(groups, setter)
+
+      return
+    }
+
+    if(isQueryAction(param1) && isArray(param2)) {
+      const action = param1
+      const parameters = param2
+      const setter = param3 as QueryDataSetter
+      const groups = getQueryGroups(action, parameters)
+
+      setDataForGroups(groups, setter)
+
+      return
+    }
+
+    if(isQueryAction(param1)) {
+      const action = param1
+      const setter = param2 as QueryDataSetter
+      const groups = getQueryGroups(action)
+
+      setDataForGroups(groups, setter)
+
+      return
+    }
+
+    assertNever(param1, 'Invalid arguments given to setQueryData')
+  }
+
   return {
     query,
     useQuery,
     defineQuery,
+    setQueryData,
   }
 }

--- a/src/createQueryClient.ts
+++ b/src/createQueryClient.ts
@@ -14,7 +14,6 @@ import { createQueryGroups } from "./createQueryGroups";
 import { createUseQuery } from "./createUseQuery";
 import { isQueryTag, isQueryTags, QueryTag } from "./types/tags";
 import { isArray } from "./utilities/arrays";
-import { F } from "vitest/dist/chunks/reporters.QZ837uWx.js";
 import { assertNever } from "./utilities/assert";
 import { QueryGroup } from "./createQueryGroup";
 

--- a/src/createQueryGroup.ts
+++ b/src/createQueryGroup.ts
@@ -1,5 +1,5 @@
 import { computed, reactive, ref, toRefs } from "vue";
-import { AwaitedQuery, Query, QueryAction, QueryOptions } from "./types/query";
+import { AwaitedQuery, Query, QueryAction, QueryData, QueryOptions } from "./types/query";
 import { createQueryId } from "./createSequence";
 import { QueryError } from "./queryError";
 import { createIntervalController } from "./services/intervalController";
@@ -12,6 +12,8 @@ export type QueryGroup<
   TAction extends QueryAction = QueryAction,
 > = {
   createQuery: <TOptions extends QueryOptions<TAction>>(options?: TOptions) => Query<TAction, TOptions>,
+  setData: (data: QueryData<TAction>) => void,
+  getData: () => QueryData<TAction>,
   hasTag: (tag: QueryTag | QueryTag[]) => boolean,
   execute: () => Promise<AwaitedQuery<TAction>>,
 }
@@ -79,6 +81,10 @@ export function createQueryGroup<
     }
 
     resolve(value)
+  }
+
+  function getData(): QueryData<TAction> {
+    return data.value
   }
 
   function setError(value: unknown): void {
@@ -226,6 +232,8 @@ export function createQueryGroup<
 
   return {
     createQuery,
+    setData,
+    getData,
     hasTag,
     execute,
   }

--- a/src/types/client.ts
+++ b/src/types/client.ts
@@ -1,12 +1,14 @@
-import { QueryActionArgs } from "./query"
+import { QueryActionArgs, QueryData } from "./query"
 import { Query } from "./query"
 import { QueryOptions } from "./query"
 import { QueryAction } from "./query"
+import { QueryTag, QueryTagType } from "./tags"
 
 export type QueryClient = {
   query: QueryFunction,
   useQuery: QueryComposition,
   defineQuery: DefineQuery,
+  setQueryData: SetQueryData,
 }
 
 export type QueryFunction = <
@@ -45,4 +47,13 @@ export type DefinedQuery<
 > = {
   query: DefinedQueryFunction<TAction, TOptions>
   useQuery: DefinedQueryComposition<TAction, TOptions>
+}
+
+export type QueryDataSetter<T = unknown> = (data: T) => T
+
+export type SetQueryData = {
+  <TQueryTag extends QueryTag>(tag: TQueryTag, setter: QueryDataSetter<QueryTagType<TQueryTag>>): void
+  <TQueryTag extends QueryTag>(tags: TQueryTag[], setter: QueryDataSetter<QueryTagType<TQueryTag>>): void
+  <TAction extends QueryAction>(action: TAction, setter: QueryDataSetter<QueryData<TAction>>): void
+  <TAction extends QueryAction>(action: TAction, parameters: Parameters<TAction>, setter: QueryDataSetter<QueryData<TAction>>): void
 }


### PR DESCRIPTION
# Description
Adds a new utility named `setQueryData` which allows manually setting the data for an individual query or any queries with the same action or tags. 

This is the first step towards supporting things like optimistic updates.

```ts
setQueryData(tagA, (data) => {
   return newData
})

setQueryData([tagA, tagB], (data) => {
  return newData
})

setQueryData(action, (data) => {
  return newData
})

setQueryData(action, params, (data) => {
  return newData
})
```
```