### PR TITLE
Add a new refreshQueryData utility to the client

### DIFF
--- a/src/createQueryClient.spec-d.ts
+++ b/src/createQueryClient.spec-d.ts
@@ -127,3 +127,24 @@ describe('setQueryData', () => {
     })
   })
 })
+
+describe('refreshQueryData', () => {
+  test('tags', () => {
+    const { refreshQueryData } = createQueryClient()
+
+    const numberTag = tag<number>()
+    const stringTag = tag<string>()
+    const action = (param: number) => param
+
+    refreshQueryData(numberTag)
+    refreshQueryData([numberTag, stringTag])
+    refreshQueryData(action)
+    refreshQueryData(action, [2])
+
+    // @ts-expect-error
+    refreshQueryData(action, [2, 3])
+
+    // @ts-expect-error
+    refreshQueryData(action, ['foo'])
+  })
+})

--- a/src/createQueryClient.spec.ts
+++ b/src/createQueryClient.spec.ts
@@ -613,3 +613,74 @@ describe('setQueryData', () => {
     expect(numberQuery2.data).toBe(2)
   })
 })
+
+describe('refreshQueryData', () => {
+  test('tags', async () => {
+    const { query, refreshQueryData } = createQueryClient()
+
+    const numberAction = vi.fn()
+    const stringAction = vi.fn()
+    const numberTag = tag<number>()
+    const stringTag = tag<string>()
+
+    query(numberAction, [], { tags: [numberTag] })
+    query(stringAction, [], { tags: [stringTag] })
+
+    await vi.runOnlyPendingTimersAsync()
+
+    expect(numberAction).toHaveBeenCalledTimes(1)
+    expect(stringAction).toHaveBeenCalledTimes(1)
+
+    refreshQueryData(numberTag)
+
+    await vi.runOnlyPendingTimersAsync()
+
+    expect(numberAction).toHaveBeenCalledTimes(2)
+    expect(stringAction).toHaveBeenCalledTimes(1)
+  })
+
+  test('action', async () => {
+    const { query, refreshQueryData } = createQueryClient()
+
+    const actionA = vi.fn()
+    const actionB = vi.fn()
+
+    query(actionA, [])
+    query(actionB, [])
+
+    await vi.runOnlyPendingTimersAsync()
+
+    expect(actionA).toHaveBeenCalledTimes(1)
+    expect(actionB).toHaveBeenCalledTimes(1)
+
+    refreshQueryData(actionA)
+
+    await vi.runOnlyPendingTimersAsync()
+
+    expect(actionA).toHaveBeenCalledTimes(2)
+    expect(actionB).toHaveBeenCalledTimes(1)
+  })
+
+  test('action with parameters', async () => {
+    const { query, refreshQueryData } = createQueryClient()
+
+    const actionA = vi.fn((param: number) => param)
+    const actionB = vi.fn((param: number) => param)
+
+    query(actionA, [1])
+    query(actionA, [2])
+    query(actionB, [1])
+
+    await vi.runOnlyPendingTimersAsync()
+
+    expect(actionA).toHaveBeenCalledTimes(2)
+    expect(actionB).toHaveBeenCalledTimes(1)
+
+    refreshQueryData(actionA, [1])
+
+    await vi.runOnlyPendingTimersAsync()
+
+    expect(actionA).toHaveBeenCalledTimes(3)
+    expect(actionB).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/createQueryClient.ts
+++ b/src/createQueryClient.ts
@@ -8,6 +8,7 @@ import {
   QueryComposition,
   QueryDataSetter,
   QueryFunction,
+  RefreshQueryData,
   SetQueryData,
 } from "./types/client";
 import { createQueryGroups } from "./createQueryGroups";
@@ -50,8 +51,8 @@ export function createQueryClient(options?: ClientOptions): QueryClient {
     param1: QueryTag | QueryTag[] | QueryAction, 
     param2: Parameters<QueryAction> | QueryDataSetter, 
     param3?: QueryDataSetter
-  ) => {
-    const setDataForGroups = (groups: QueryGroup[], setter: QueryDataSetter) => {
+  ): void => {
+    const setDataForGroups = (groups: QueryGroup[], setter: QueryDataSetter): void => {
       groups.forEach(group => {
         const data = group.getData()
         const newData = setter(data)
@@ -94,10 +95,53 @@ export function createQueryClient(options?: ClientOptions): QueryClient {
     assertNever(param1, 'Invalid arguments given to setQueryData')
   }
 
+  const refreshQueryData: RefreshQueryData = (
+    param1: QueryTag | QueryTag[] | QueryAction, 
+    param2?: Parameters<QueryAction>, 
+  ): void => {
+
+    if(isQueryTag(param1) || isQueryTags(param1)) {
+      const tags = param1
+      const groups = getQueryGroups(tags)
+
+      groups.forEach(group => {
+        group.execute()
+      })
+
+      return
+    }
+
+    if(isQueryAction(param1) && isArray(param2)) {
+      const action = param1
+      const parameters = param2
+      const groups = getQueryGroups(action, parameters)
+
+      groups.forEach(group => {
+        group.execute()
+      })
+
+      return
+    }
+
+    if(isQueryAction(param1)) {
+      const action = param1
+      const groups = getQueryGroups(action)
+
+      groups.forEach(group => {
+        group.execute()
+      })
+
+      return
+    }
+
+    assertNever(param1, 'Invalid arguments given to setQueryData')
+  }
+
   return {
     query,
     useQuery,
     defineQuery,
     setQueryData,
+    refreshQueryData,
   }
 }

--- a/src/types/client.ts
+++ b/src/types/client.ts
@@ -9,6 +9,7 @@ export type QueryClient = {
   useQuery: QueryComposition,
   defineQuery: DefineQuery,
   setQueryData: SetQueryData,
+  refreshQueryData: RefreshQueryData,
 }
 
 export type QueryFunction = <
@@ -52,8 +53,13 @@ export type DefinedQuery<
 export type QueryDataSetter<T = unknown> = (data: T) => T
 
 export type SetQueryData = {
-  <TQueryTag extends QueryTag>(tag: TQueryTag, setter: QueryDataSetter<QueryTagType<TQueryTag>>): void
-  <TQueryTag extends QueryTag>(tags: TQueryTag[], setter: QueryDataSetter<QueryTagType<TQueryTag>>): void
+  <TQueryTag extends QueryTag>(tag: TQueryTag | TQueryTag[], setter: QueryDataSetter<QueryTagType<TQueryTag>>): void
   <TAction extends QueryAction>(action: TAction, setter: QueryDataSetter<QueryData<TAction>>): void
   <TAction extends QueryAction>(action: TAction, parameters: Parameters<TAction>, setter: QueryDataSetter<QueryData<TAction>>): void
+}
+
+export type RefreshQueryData = {
+  <TQueryTag extends QueryTag>(tag: TQueryTag | TQueryTag[]): void
+  <TAction extends QueryAction>(action: TAction): void
+  <TAction extends QueryAction>(action: TAction, parameters: Parameters<TAction>): void
 }


### PR DESCRIPTION
# Description
Adding a new `refreshQueryData` utility to the client that accepts
- A tag
- Multiple tags
- An action
- An action and specific parameters

It then gets any query groups that match the arguments and executes the action. This is a way to make sure that certain queries are up to date without creating new queries. Which allows for refreshing the data for any existing queries that might exist. 