### PR TITLE
Add a `mutate` utility to the client

### DIFF
--- a/src/createMutation.ts
+++ b/src/createMutation.ts
@@ -1,0 +1,83 @@
+import { reactive, ref, toRefs } from "vue";
+import { MutationAction, MutationOptions, Mutation, MutationData, MutationTags } from "./types/mutation";
+import { QueryError } from "./queryError";
+import { reduceRetryOptions, retry, RetryOptions } from "./utilities/retry";
+
+export function createMutation<
+  TAction extends MutationAction,
+  TPlaceholder extends unknown,
+  TTags extends MutationTags<TAction>,
+>(action: TAction, parameters: Parameters<TAction>, options?: MutationOptions<TAction, TPlaceholder, TTags>): Mutation<TAction, TPlaceholder> {
+  const data = ref()
+  const executing = ref<boolean>(false)
+  const executed = ref<boolean>(false)
+  const error = ref<unknown>()
+  const errored = ref<boolean>(false)
+  const { promise, resolve } = Promise.withResolvers()
+
+  async function execute(): Promise<MutationData<TAction>> {
+    executing.value = true
+
+    try {
+      const value = await retry(() => action(...parameters), getRetryOptions())
+      
+      setData(value)
+
+      return data.value
+    } catch(error) {
+      setError(error)
+
+      throw error
+    } finally {
+      executing.value = false
+      executed.value = true
+    } 
+  }
+
+  function setData(value: Awaited<ReturnType<TAction>>): void {
+    error.value = undefined
+    errored.value = false
+    data.value = value
+
+    options?.onSuccess?.(value)
+
+    resolve(value)
+  }
+
+  function setError(value: unknown): void {
+    error.value = value
+    errored.value = true
+
+    options?.onError?.(value)
+
+    resolve(new QueryError(value))
+  }
+
+  function getRetryOptions(): RetryOptions {
+    return reduceRetryOptions([options?.retries])
+  }
+
+  const mutation: Omit<Mutation<TAction, TPlaceholder>, 'then'> = reactive({
+    data,
+    executing,
+    executed,
+    error,
+    errored,
+    execute,
+  })
+
+  const then: Mutation<TAction, TPlaceholder>['then'] = (onFulfilled: any, onRejected: any) => {
+    return promise.then((value) => {
+      if(value instanceof QueryError) {
+        throw value.original
+      }
+
+      return mutation
+    }).then(onFulfilled, onRejected)
+  }
+
+  return reactive({
+    ...toRefs(mutation),
+    then
+  })
+}

--- a/src/createQueryClient.spec-d.ts
+++ b/src/createQueryClient.spec-d.ts
@@ -1,4 +1,4 @@
-import { describe, expectTypeOf, test } from "vitest"
+import { describe, expectTypeOf, test, vi } from "vitest"
 import { createQueryClient } from "./createQueryClient"
 import { tag } from "./tag"
 
@@ -146,5 +146,37 @@ describe('refreshQueryData', () => {
 
     // @ts-expect-error
     refreshQueryData(action, ['foo'])
+  })
+})
+
+describe('mutate', () => {
+  test('setQueryDataBefore', () => {
+    const { mutate } = createQueryClient()
+    const action = vi.fn(() => 'response')
+    const numberTag = tag<number>()
+
+    mutate(action, [], { 
+      tags: [numberTag],
+      setQueryDataBefore: (data) => {
+        expectTypeOf(data).toMatchTypeOf<number>()
+
+        return 1
+      }
+    })
+  })
+
+  test('setQueryDataAfter', () => {
+    const { mutate } = createQueryClient()
+    const action = vi.fn()
+    const numberTag = tag<number>()
+    
+    mutate(action, [], { 
+      tags: [numberTag],
+      setQueryDataAfter: (data) => {
+        expectTypeOf(data).toMatchTypeOf<number>()
+
+        return 1
+      }
+    })
   })
 })

--- a/src/getAllTags.spec.ts
+++ b/src/getAllTags.spec.ts
@@ -1,0 +1,26 @@
+import { expect, test } from "vitest";
+import { getAllTags } from "./getAllTags";
+import { tag } from "./tag";
+
+const tagA = tag()
+const tagB = tag()
+const tagC = tag((input: string) => input)
+
+test('given tags returns all tags', () => {
+  const tags = getAllTags([tagA, tagB, tagC('foo')], undefined)
+
+  expect(tags).toEqual([tagA, tagB, tagC('foo')])
+})
+
+test('given a function returns all tags', () => {
+  const tags = getAllTags((input: string) => [tagA, tagB, tagC(input)], 'foo')
+
+  expect(tags).toEqual([tagA, tagB, tagC('foo')])
+})
+
+test('given no tags returns an empty array', () => {
+  const tags = getAllTags(undefined, undefined)
+
+  expect(tags).toEqual([])
+})
+

--- a/src/getAllTags.ts
+++ b/src/getAllTags.ts
@@ -1,0 +1,13 @@
+import { MutationTags } from "./types/mutation"
+import { QueryTags } from "./types/query"
+import { QueryTag } from "./types/tags"
+
+export function getAllTags<
+  TTags extends QueryTags | MutationTags | undefined,
+>(tags: TTags, data: unknown): QueryTag[] {
+  if(typeof tags === 'function') {
+    return tags(data)
+  }
+
+  return tags ?? []
+}

--- a/src/types/client.ts
+++ b/src/types/client.ts
@@ -1,3 +1,4 @@
+import { MutationFunction } from "./mutation"
 import { QueryActionArgs, QueryData } from "./query"
 import { Query } from "./query"
 import { QueryOptions } from "./query"
@@ -10,6 +11,7 @@ export type QueryClient = {
   defineQuery: DefineQuery,
   setQueryData: SetQueryData,
   refreshQueryData: RefreshQueryData,
+  mutate: MutationFunction,
 }
 
 export type QueryFunction = <

--- a/src/types/mutation.ts
+++ b/src/types/mutation.ts
@@ -3,6 +3,8 @@ import { QueryTag, QueryTagType } from "./tags"
 
 export type MutationAction = (...args: any[]) => any
 
+export type MutationData<TAction extends MutationAction> = Awaited<ReturnType<TAction>>
+
 export type MutationTags<
   TAction extends MutationAction = MutationAction,
 > = QueryTag[] | ((value: MutationData<TAction>) => QueryTag[])
@@ -37,13 +39,11 @@ export type MutationOptions<
   tags?: TTags,
   refreshQueryData?: boolean,
   retries?: number | Partial<RetryOptions>,
-  onSuccess?: (value: Awaited<ReturnType<TAction>>) => void,
+  onSuccess?: (value: MutationData<TAction>) => void,
   onError?: (error: unknown) => void,
   setQueryDataBefore?: (queryData: MutationTagsType<TTags>, context: SetQueryDataBeforeContext<TAction>) => MutationTagsType<TTags>,
   setQueryDataAfter?: (queryData: MutationTagsType<TTags>, context: SetQueryDataAfterContext<TAction>) => MutationTagsType<TTags>,
 }
-
-export type MutationData<TAction extends MutationAction> = Awaited<ReturnType<TAction>>
 
 export type Mutation<
   TAction extends MutationAction,
@@ -54,7 +54,7 @@ export type Mutation<
   executed: boolean,
   error: unknown,
   errored: boolean,
-  execute: () => Promise<Awaited<ReturnType<TAction>>>,
+  execute: () => Promise<MutationData<TAction>>,
 }
 
 export type AwaitedMutation<

--- a/src/types/mutation.ts
+++ b/src/types/mutation.ts
@@ -38,9 +38,9 @@ export type MutationOptions<
   refreshQueryData?: boolean,
   retries?: number | Partial<RetryOptions>,
   onSuccess?: (value: Awaited<ReturnType<TAction>>) => void,
+  onError?: (error: unknown) => void,
   setQueryDataBefore?: (queryData: MutationTagsType<TTags>, context: SetQueryDataBeforeContext<TAction>) => MutationTagsType<TTags>,
   setQueryDataAfter?: (queryData: MutationTagsType<TTags>, context: SetQueryDataAfterContext<TAction>) => MutationTagsType<TTags>,
-  onError?: (error: unknown) => void,
 }
 
 export type MutationData<TAction extends MutationAction> = Awaited<ReturnType<TAction>>

--- a/src/types/mutation.ts
+++ b/src/types/mutation.ts
@@ -3,7 +3,9 @@ import { QueryTag, QueryTagType } from "./tags"
 
 export type MutationAction = (...args: any[]) => any
 
-export type MutationData<TAction extends MutationAction> = Awaited<ReturnType<TAction>>
+export type MutationData<
+  TAction extends MutationAction
+> = Awaited<ReturnType<TAction>>
 
 export type MutationTags<
   TAction extends MutationAction = MutationAction,

--- a/src/types/query.ts
+++ b/src/types/query.ts
@@ -8,14 +8,16 @@ export function isQueryAction(value: any): value is QueryAction {
   return typeof value === 'function'
 }
 
-export type QueryData<TAction extends QueryAction> = Awaited<ReturnType<TAction>>
+export type QueryData<
+  TAction extends QueryAction = QueryAction
+> = Awaited<ReturnType<TAction>>
 
 export type QueryActionArgs<
   TAction extends QueryAction
 > = MaybeGetter<Parameters<TAction>> | Getter<Parameters<TAction> | null> | Getter<null>
 
 export type QueryTags<
-  TAction extends QueryAction,
+  TAction extends QueryAction = QueryAction,
 > = QueryTag<QueryData<TAction> | Unset>[] | ((value: QueryData<TAction>) => QueryTag<QueryData<TAction> | Unset>[])
 
 export type QueryOptions<


### PR DESCRIPTION
# Description
Mutations are similar to queries but serve a very different purpose. Mutations are designed to post data and then react to the data changes by effecting your queries. Mutations work by calling a mutation action, which works exactly the same as a query action. You pass the action, then you pass the arguments to pass to the action. Mutations also support `retries`, `onSuccess`, `onError` and `placeholder` options same as queries. 

```ts
const { query, mutation } = createQueryClient()

const user = query(getUser, [userId])

mutate(updateUser, [userId, user])
```

Mutations differ from queries in a few ways
- Mutations are not cached
- Tags passed to mutations relate mutations to queries (rather than tagging the mutation itself like queries do)

## Tags
When you add a tag to a mutation, it will automatically refresh the data for any active queries with that same tag. In this example, the user query will automatically be refreshed after the mutation finishes

```ts
const user = query(getUser, [userId], {
  tags: [usersTag]
})

mutate(updateUser, [userId, user], {
  tags: [usersTag]
})
```

Tags can also be defined based on the data returned by the action
```ts
mutate(updateUser, [userId, user], {
  tags: (user) => [userTag(user.id]
})
```

You can also disable the automatic refreshing based on tags by passing `refreshQueryData: false`
```ts
mutate(updateUser, [userId, user], {
  tags: (user) => [userTag(user.id],
  refreshQueryData: false,
})
```

## Updating Queries
You might want do optimistically update your query data based on the mutation being executed, or update your query data based on the mutation executing successfully. You can already update query data manually using using `setQueryData`, so you could do something like this
```ts
const mutation = mutate(updateUser, [userId, user], {
  tags: (user) => [userTag(user.id],
  refreshQueryData: false,
})

// update queries immediately
setQueryData(userTag(user.id), (data) => {
  ...
})

// update queries once the mutation finishes executing
const { data: updatedUser } = await mutation

setQueryData(userTag(user.id), (data) => {
  ...
})

```

But `mutate` also allows passing in both a `setQueryDataBefore` and `setQueryDataAfter` callback which will automatically update queries based on the tags on the mutation. 
```ts
mutate(updateUser, [userId, user], {
  tags: [userTag(userId)],
  setQueryDataBefore: (queryData, context) => {
    ...
  },
  setQueryDataAfter: (queryData, context) => {
    ...
  }
```
The context for `setQueryDataBefore` has a single `payload` property which are the values passed to the mutation's action. The context for `setQueryDataAfter` includes both the `payload` and the `data` returned by the mutation's action.