### PR TITLE
Add useMutation composition

### DIFF
--- a/src/types/client.ts
+++ b/src/types/client.ts
@@ -1,4 +1,4 @@
-import { MutationFunction } from "./mutation"
+import { MutationFunction, MutationComposition } from "./mutation"
 import { QueryActionArgs, QueryData } from "./query"
 import { Query } from "./query"
 import { QueryOptions } from "./query"
@@ -12,6 +12,7 @@ export type QueryClient = {
   setQueryData: SetQueryData,
   refreshQueryData: RefreshQueryData,
   mutate: MutationFunction,
+  useMutation: MutationComposition,
 }
 
 export type QueryFunction = <

--- a/src/types/mutation.ts
+++ b/src/types/mutation.ts
@@ -110,7 +110,7 @@ export type MutationComposition = <
   const TAction extends MutationAction,
   const TPlaceholder extends unknown,
   const TTags extends MutationTags<TAction>,
->(action: TAction, options?: MutationOptions<TAction, TPlaceholder, TTags>) => { mutate: Mutate<TAction> } & Mutation<TAction, TPlaceholder>
+>(action: TAction, options?: MutationOptions<TAction, TPlaceholder, TTags>) => Mutation<TAction, TPlaceholder>
 
 export type DefinedMutationComposition<
   TAction extends MutationAction,


### PR DESCRIPTION
# Description
Adds a new `useMutation` composition to the client. This works exactly the same as the `mutation` utility except its designed to be used in a component context. It doesn't yet require the context or use the context for anything, but its more ergonomic for component devx. 

The differences between `mutate` and `useMutation`
- Parameters are not passed when calling the composition
- The mutation is not executed immediately, the `mutate` function returned by the composition must be called. Similar to calling `query.execute()`