### PR TITLE
Add `defineMutation` utility to the client

### DIFF
--- a/src/createMutation.ts
+++ b/src/createMutation.ts
@@ -8,7 +8,7 @@ export function createMutation<
   TPlaceholder extends unknown,
   TTags extends MutationTags<TAction>,
 >(action: TAction, options?: MutationOptions<TAction, TPlaceholder, TTags>): Mutation<TAction, TPlaceholder> {
-  const data = ref()
+  const data = ref<any>(options?.placeholder)
   const executing = ref<boolean>(false)
   const executed = ref<boolean>(false)
   const error = ref<unknown>()

--- a/src/createQueryClient.spec-d.ts
+++ b/src/createQueryClient.spec-d.ts
@@ -129,6 +129,52 @@ describe('setQueryData', () => {
 })
 
 describe('refreshQueryData', () => {
+  test('data', async () => {
+    const { mutate, useMutation } = createQueryClient()
+
+    const action = (value: number) => value
+
+    const mutationA = useMutation(action)
+    const mutationB = mutate(action, [1])
+
+    expectTypeOf(mutationA.data).toEqualTypeOf<number | undefined>()
+    expectTypeOf(mutationB.data).toEqualTypeOf<number | undefined>()
+
+    const mutationC = await useMutation(action)
+    const mutationD = await mutate(action, [1])
+
+    expectTypeOf(mutationC.data).toEqualTypeOf<number>()
+    expectTypeOf(mutationD.data).toEqualTypeOf<number>()
+  })
+
+  test('placeholder', async () => {
+    const { mutate, useMutation } = createQueryClient()
+
+    const action = (value: number) => value
+
+    const mutationA = useMutation(action, {
+      placeholder: 'foo'
+    })
+
+    const mutationB = mutate(action, [1], {
+      placeholder: 'foo'
+    })
+
+    expectTypeOf(mutationA.data).toEqualTypeOf<number | 'foo'>()
+    expectTypeOf(mutationB.data).toEqualTypeOf<number | 'foo'>()
+
+    const mutationC = await useMutation(action, {
+      placeholder: 'foo'
+    })
+
+    const mutationD = await mutate(action, [1], {
+      placeholder: 'foo'
+    })
+
+    expectTypeOf(mutationC.data).toEqualTypeOf<number>()
+    expectTypeOf(mutationD.data).toEqualTypeOf<number>()
+  })
+
   test('tags', () => {
     const { refreshQueryData } = createQueryClient()
 
@@ -177,6 +223,83 @@ describe('mutate', () => {
 
         return 1
       }
+    })
+  })
+})
+
+describe('defineMutation', () => {
+
+  test('response', async () => {
+    const { defineMutation } = createQueryClient()
+
+    const action = (value: number) => value
+
+    const { mutate, useMutation } = defineMutation(action)
+
+    const mutationA = useMutation()
+    const mutationB = mutate([1])
+
+    expectTypeOf(mutationA.data).toEqualTypeOf<number | undefined>()
+    expectTypeOf(mutationA.executing).toEqualTypeOf<boolean>()
+    expectTypeOf(mutationA.executed).toEqualTypeOf<boolean>()
+    expectTypeOf(mutationA.error).toEqualTypeOf<unknown>()
+    expectTypeOf(mutationA.errored).toEqualTypeOf<boolean>()
+
+    expectTypeOf(mutationB.executing).toEqualTypeOf<boolean>()
+    expectTypeOf(mutationB.executed).toEqualTypeOf<boolean>()
+    expectTypeOf(mutationB.error).toEqualTypeOf<unknown>()
+    expectTypeOf(mutationB.errored).toEqualTypeOf<boolean>()
+    expectTypeOf(mutationB.data).toEqualTypeOf<number | undefined>()
+
+    const mutationC = await useMutation()
+    const mutationD = await mutate([1])
+
+    expectTypeOf(mutationC.data).toEqualTypeOf<number>()
+    expectTypeOf(mutationD.data).toEqualTypeOf<number>()
+  })
+
+  describe('options', () => {
+    test('placeholder', async () => {
+      const { defineMutation } = createQueryClient()
+
+      const action = (value: number) => value
+
+      const { mutate, useMutation } = defineMutation(action, {
+        placeholder: 'foo'
+      })
+
+      const mutationA = useMutation()
+      const mutationB = mutate([1])
+
+      expectTypeOf(mutationA.data).toEqualTypeOf<number | 'foo'>()
+      expectTypeOf(mutationB.data).toEqualTypeOf<number | 'foo'>()
+
+      const mutationC = useMutation({
+        placeholder: 'bar'
+      })
+
+      const mutationD = mutate([1], {
+        placeholder: 'bar'
+      })
+
+      expectTypeOf(mutationC.data).toEqualTypeOf<number | 'bar'>()
+      expectTypeOf(mutationD.data).toEqualTypeOf<number | 'bar'>()
+
+      const mutationE = await useMutation()
+      const mutationF = await mutate([1])
+
+      const mutationG = await useMutation({
+        placeholder: 'bar'
+      })
+
+      const mutationH = await mutate([1], {
+        placeholder: 'bar'
+      })
+
+      expectTypeOf(mutationE.data).toEqualTypeOf<number>()
+      expectTypeOf(mutationF.data).toEqualTypeOf<number>()
+      expectTypeOf(mutationG.data).toEqualTypeOf<number>()
+      expectTypeOf(mutationH.data).toEqualTypeOf<number>()
     })
   })
 })

--- a/src/types/client.ts
+++ b/src/types/client.ts
@@ -1,4 +1,4 @@
-import { MutationFunction, MutationComposition } from "./mutation"
+import { MutationFunction, MutationComposition, DefineMutation } from "./mutation"
 import { QueryActionArgs, QueryData } from "./query"
 import { Query } from "./query"
 import { QueryOptions } from "./query"
@@ -13,6 +13,7 @@ export type QueryClient = {
   refreshQueryData: RefreshQueryData,
   mutate: MutationFunction,
   useMutation: MutationComposition,
+  defineMutation: DefineMutation,
 }
 
 export type QueryFunction = <

--- a/src/types/mutation.ts
+++ b/src/types/mutation.ts
@@ -1,5 +1,6 @@
 import { RetryOptions } from "@/utilities/retry"
 import { QueryTag, QueryTagType } from "./tags"
+import { DefaultValue } from "./utilities"
 
 export type MutationAction = (...args: any[]) => any
 
@@ -72,7 +73,7 @@ export type Mutation<
   TAction extends MutationAction,
   TPlaceholder extends unknown,
 > = PromiseLike<AwaitedMutation<TAction>> & {
-  data: MutationData<TAction> | TPlaceholder,
+  data: MutationData<TAction> | DefaultValue<TPlaceholder, undefined>,
   executing: boolean,
   executed: boolean,
   error: unknown,
@@ -97,14 +98,12 @@ export type MutationFunction = <
 >(action: TAction, args: Parameters<TAction>, options?: MutationOptions<TAction, TPlaceholder, TTags>) => PromiseLike<AwaitedMutation<TAction>> & Mutation<TAction, TPlaceholder>
 
 export type DefinedMutationFunction<
-  TAction extends MutationAction,
-  TPlaceholder extends unknown,
-  TTags extends MutationTags<TAction>,
-> = (args: Parameters<TAction>, options?: MutationOptions<TAction, TPlaceholder, TTags>) => Mutation<TAction, TPlaceholder>
-
-type Mutate<
-  TAction extends MutationAction
-> = (...args: Parameters<TAction>) => ReturnType<TAction>
+  TDefinedAction extends MutationAction,
+  TDefinedPlaceholder extends unknown,
+> = <
+  const TPlaceholder extends unknown,
+  const TTags extends MutationTags<TDefinedAction>
+>(args: Parameters<TDefinedAction>, options?: MutationOptions<TDefinedAction, TPlaceholder, TTags>) => Mutation<TDefinedAction, DefaultValue<TPlaceholder, TDefinedPlaceholder>>
 
 export type MutationComposition = <
   const TAction extends MutationAction,
@@ -113,23 +112,24 @@ export type MutationComposition = <
 >(action: TAction, options?: MutationOptions<TAction, TPlaceholder, TTags>) => Mutation<TAction, TPlaceholder>
 
 export type DefinedMutationComposition<
-  TAction extends MutationAction,
-  TPlaceholder extends unknown,
-  TTags extends MutationTags<TAction>,
-> = (options?: MutationOptions<TAction, TPlaceholder, TTags>) => { mutate: Mutate<TAction> } & Mutation<TAction, TPlaceholder>
+  TDefinedAction extends MutationAction,
+  TDefinedPlaceholder extends unknown,
+> = <
+  const TPlaceholder extends unknown,
+  const TTags extends MutationTags<TDefinedAction>
+>(options?: MutationOptions<TDefinedAction, TPlaceholder, TTags>) => Mutation<TDefinedAction, DefaultValue<TPlaceholder, TDefinedPlaceholder>>
 
 export type DefinedMutation<
   TAction extends MutationAction,
   TPlaceholder extends unknown,
-  TTags extends MutationTags<TAction>,
 > = {
-  mutate: DefinedMutationFunction<TAction, TPlaceholder, TTags>,
-  useMutation: DefinedMutationComposition<TAction, TPlaceholder, TTags>,
+  mutate: DefinedMutationFunction<TAction, TPlaceholder>,
+  useMutation: DefinedMutationComposition<TAction, TPlaceholder>,
 }
 
 export type DefineMutation = <
   const TAction extends MutationAction,
   const TPlaceholder extends unknown,
   const TTags extends MutationTags<TAction>,
->(action: TAction, options?: MutationOptions<TAction, TPlaceholder, TTags>) => DefinedMutation<TAction, TPlaceholder, TTags>
+>(action: TAction, options?: MutationOptions<TAction, TPlaceholder, TTags>) => DefinedMutation<TAction, TPlaceholder>
 

--- a/src/types/utilities.ts
+++ b/src/types/utilities.ts
@@ -1,0 +1,1 @@
+export type DefaultValue<TValue, TDefault> = unknown extends TValue ? TDefault : TValue

--- a/src/utilities/retry.spec.ts
+++ b/src/utilities/retry.spec.ts
@@ -63,6 +63,20 @@ describe('retry', () => {
     expect(callback).toHaveBeenCalledTimes(4)
   })
 
+  test('should not wait if delay is 0', async () => {
+    vi.useRealTimers()
+    const error = new Error('test')
+    const callback = vi.fn(() => {
+      throw error
+    })
+
+    const result = retry(callback, { count: 10, delay: 0 })
+
+    expect(callback).toHaveBeenCalledTimes(11)
+    await expect(result).rejects.toBe(error)
+    vi.useFakeTimers()
+  })
+
 })
 
 describe('reduceRetryOptions', () => {

--- a/src/utilities/retry.ts
+++ b/src/utilities/retry.ts
@@ -48,7 +48,9 @@ export async function retry<T>(action: RetryCallback<T>, options: RetryOptions, 
       throw error
     }
 
-    await timeout(delay)
+    if(delay > 0) {
+      await timeout(delay)
+    }
 
     return retry(action, options, count + 1)
   }


### PR DESCRIPTION
# Description
The `defineMutation` utility serves the same purpose as the `defineQuery` utility except for mutations. You can predefine a mutation with its action and options and then use it later. 

```ts
const { mutate: mutateUser, useMutation: useUserMutation } = defineMutation(mutateUserAction, { ... })
```

## Options
`defineMutation` accepts all the same options as regular mutations do. If you pass tags it will use those tags for refreshing queries, and to provide context to the `setQueryDataBefore` and `setQueryDataAfter` callbacks. 

You can also provide options when calling the defined mutation
```ts
const { mutate } = defineMutation(...)

const result = mutate(..., {
  tags: [tagA, tagB],
  ...
})
```
Some options override the options from the definition and some add additional callbacks. For example, a `placeholder` passed to the mutation when it is called will override the placeholder provided by the definition. Same for `retries` and `refreshQueryData`. 

However `tags`, and any callbacks provided via options are run separately. The definition can have its own business logic for what tags to use and what callbacks to run. And they'll run in the background automatically. But the mutation can provide its own tags and callbacks to be run separately from what was provided in the definition. 