### PR TITLE
Abstract logic for defined query and mutation options and fix types for query placeholders

### DIFF
--- a/src/createQueryClient.spec-d.ts
+++ b/src/createQueryClient.spec-d.ts
@@ -24,6 +24,84 @@ describe('options', () => {
   })
 })
 
+describe('query', () => {
+  describe('options', () => {
+    test('placeholder', async () => {
+      const { query } = createQueryClient()
+      const response = 'response' as const
+      const placeholder = 'placeholder' as const
+      const action = () => response
+
+      const queryA = query(action, [])
+      expectTypeOf(queryA.data).toEqualTypeOf<typeof response | undefined>()
+      
+      const queryB = query(action, [], { placeholder })
+      expectTypeOf(queryB.data).toEqualTypeOf<typeof response | typeof placeholder>()
+
+      const queryC = await query(action, [])
+      expectTypeOf(queryC.data).toEqualTypeOf<typeof response>()
+
+      const queryD = await query(action, [], { placeholder })
+      expectTypeOf(queryD.data).toEqualTypeOf<typeof response>()
+      
+    })
+  })
+})
+
+describe('useQuery', () => {
+  describe('options', () => {
+    test('placeholder', async () => {
+      const { useQuery } = createQueryClient()
+      const response = 'response' as const
+      const placeholder = 'placeholder' as const
+      const action = () => response
+
+      const queryA = useQuery(action, [])
+      expectTypeOf(queryA.data).toEqualTypeOf<typeof response | undefined>()
+      
+      const queryB = useQuery(action, [], { placeholder })
+      expectTypeOf(queryB.data).toEqualTypeOf<typeof response | typeof placeholder>()
+
+      const queryC = await useQuery(action, [])
+      expectTypeOf(queryC.data).toEqualTypeOf<typeof response>()
+
+      const queryD = await useQuery(action, [], { placeholder })
+      expectTypeOf(queryD.data).toEqualTypeOf<typeof response>()
+      
+    })
+  })
+})
+
+describe('defineQuery', () => {
+  describe('options', () => {
+    test('placeholder', async () => {
+      const { defineQuery } = createQueryClient()
+      const response = 'response' as const
+      const definedPlaceholder = 'defined placeholder' as const
+      const placeholder = 'placeholder' as const
+      const action = () => response
+
+      const { query: definedWithNoPlaceholder } = defineQuery(action)
+      const queryA = definedWithNoPlaceholder([])
+      expectTypeOf(queryA.data).toEqualTypeOf<typeof response | undefined>()
+
+      const { query: definedWithPlaceholder } = defineQuery(action, { placeholder: definedPlaceholder })
+
+      const queryB = definedWithPlaceholder([])
+      expectTypeOf(queryB.data).toEqualTypeOf<typeof response | typeof definedPlaceholder>()
+      
+      const queryC = definedWithPlaceholder([], { placeholder })
+      expectTypeOf(queryC.data).toEqualTypeOf<typeof response | typeof placeholder>()
+
+      const queryD = await definedWithPlaceholder([])
+      expectTypeOf(queryD.data).toEqualTypeOf<typeof response>()
+
+      const queryE = await definedWithPlaceholder([], { placeholder })
+      expectTypeOf(queryE.data).toEqualTypeOf<typeof response>()
+    })
+  })
+})
+
 describe('setQueryData', () => {
   test('tags', async () => {
     const { setQueryData } = createQueryClient()

--- a/src/createQueryGroups.ts
+++ b/src/createQueryGroups.ts
@@ -10,8 +10,8 @@ type QueryGroupKey = `${number}-${string}`
 
 export type CreateQuery = <
   const TAction extends QueryAction,
-  const TOptions extends QueryOptions<TAction>
->(action: TAction, parameters: Parameters<TAction>, options?: TOptions) => Query<TAction, TOptions>
+  const TPlaceholder extends unknown
+>(action: TAction, parameters: Parameters<TAction>, options?: QueryOptions<TAction, TPlaceholder>) => Query<TAction, TPlaceholder>
 
 export type GetQueryGroups = {
   <TQueryTag extends QueryTag>(tags: TQueryTag | TQueryTag[]): QueryGroup[]

--- a/src/createUseQuery.ts
+++ b/src/createUseQuery.ts
@@ -1,5 +1,5 @@
 import { CreateQuery } from "./createQueryGroups"
-import { Query, QueryAction, QueryActionArgs, QueryOptions } from "./types/query"
+import { Query, QueryAction, QueryActionArgs } from "./types/query"
 import { onScopeDispose, ref, toRef, toRefs, toValue, watch } from "vue"
 import isEqual from 'lodash.isequal'
 import { isDefined } from "./utilities"
@@ -10,10 +10,10 @@ const noop = () => undefined
 export function createUseQuery<
   TAction extends QueryAction,
   TArgs extends QueryActionArgs<TAction>,
-  TOptions extends UseQueryOptions<TAction>
->(createQuery: CreateQuery, action: TAction, parameters: TArgs, options?: TOptions): Query<TAction, TOptions>
+  TPlaceholder extends unknown
+>(createQuery: CreateQuery, action: TAction, parameters: TArgs, options?: UseQueryOptions<TAction, TPlaceholder>): Query<TAction, TPlaceholder>
 
-export function createUseQuery(createQuery: CreateQuery, action: QueryAction, parameters: unknown[], options: UseQueryOptions<QueryAction> = {}): Query<QueryAction, QueryOptions<QueryAction>> {
+export function createUseQuery(createQuery: CreateQuery, action: QueryAction, parameters: unknown[], options: UseQueryOptions<QueryAction, unknown> = {}): Query<QueryAction, unknown> {
   const query = createQuery(noop, [], options)
   const enabled = ref(options?.immediate ?? true)
   const { promise, resolve, reject } = Promise.withResolvers()

--- a/src/createUseQuery.ts
+++ b/src/createUseQuery.ts
@@ -13,7 +13,7 @@ export function createUseQuery<
   TPlaceholder extends unknown
 >(createQuery: CreateQuery, action: TAction, parameters: TArgs, options?: UseQueryOptions<TAction, TPlaceholder>): Query<TAction, TPlaceholder>
 
-export function createUseQuery(createQuery: CreateQuery, action: QueryAction, parameters: unknown[], options: UseQueryOptions<QueryAction, unknown> = {}): Query<QueryAction, unknown> {
+export function createUseQuery(createQuery: CreateQuery, action: QueryAction, parameters: unknown[], options: UseQueryOptions = {}): Query<QueryAction, unknown> {
   const query = createQuery(noop, [], options)
   const enabled = ref(options?.immediate ?? true)
   const { promise, resolve, reject } = Promise.withResolvers()

--- a/src/types/client.ts
+++ b/src/types/client.ts
@@ -30,8 +30,8 @@ export type DefinedQueryFunction<
 >(args: Parameters<TAction>, options?: QueryOptions<TAction, TPlaceholder>) => Query<TAction, DefaultValue<TPlaceholder, TDefinedPlaceholder>>
 
 export type UseQueryOptions<
-  TAction extends QueryAction,
-  TPlaceholder extends unknown
+  TAction extends QueryAction = QueryAction,
+  TPlaceholder extends unknown = unknown
 > = QueryOptions<TAction, TPlaceholder> & {
   immediate?: boolean,
 }

--- a/src/types/client.ts
+++ b/src/types/client.ts
@@ -4,6 +4,7 @@ import { Query } from "./query"
 import { QueryOptions } from "./query"
 import { QueryAction } from "./query"
 import { QueryTag, QueryTagType } from "./tags"
+import { DefaultValue } from "./utilities"
 
 export type QueryClient = {
   query: QueryFunction,
@@ -18,40 +19,47 @@ export type QueryClient = {
 
 export type QueryFunction = <
   const TAction extends QueryAction,
-  const TOptions extends QueryOptions<TAction>
->(action: TAction, args: Parameters<TAction>, options?: TOptions) => Query<TAction, TOptions>
+  const TPlaceholder extends unknown
+>(action: TAction, args: Parameters<TAction>, options?: QueryOptions<TAction, TPlaceholder>) => Query<TAction, TPlaceholder>
 
 export type DefinedQueryFunction<
   TAction extends QueryAction,
-  TOptions extends QueryOptions<TAction>
-> = (args: Parameters<TAction>, options?: TOptions) => Query<TAction, TOptions>
+  TDefinedPlaceholder extends unknown
+> = <
+  const TPlaceholder extends unknown
+>(args: Parameters<TAction>, options?: QueryOptions<TAction, TPlaceholder>) => Query<TAction, DefaultValue<TPlaceholder, TDefinedPlaceholder>>
 
-export type UseQueryOptions<TAction extends QueryAction> = QueryOptions<TAction> & {
+export type UseQueryOptions<
+  TAction extends QueryAction,
+  TPlaceholder extends unknown
+> = QueryOptions<TAction, TPlaceholder> & {
   immediate?: boolean,
 }
 
 export type QueryComposition = <
   const TAction extends QueryAction,
   const Args extends QueryActionArgs<TAction>,
-  const TOptions extends UseQueryOptions<TAction>
->(action: TAction, args: Args, options?: TOptions) => Query<TAction, TOptions>
+  const TPlaceholder extends unknown
+>(action: TAction, args: Args, options?: UseQueryOptions<TAction, TPlaceholder>) => Query<TAction, TPlaceholder>
 
 export type DefinedQueryComposition<
   TAction extends QueryAction,
-  TOptions extends QueryOptions<TAction>
-> = (args: QueryActionArgs<TAction>, options?: TOptions) => Query<TAction, TOptions>
+  TDefinedPlaceholder extends unknown
+> = <
+  const TPlaceholder extends unknown
+>(args: QueryActionArgs<TAction>, options?: QueryOptions<TAction, TPlaceholder>) => Query<TAction, DefaultValue<TPlaceholder, TDefinedPlaceholder>>
 
 export type DefineQuery = <
   const TAction extends QueryAction,
-  const TOptions extends QueryOptions<TAction>
->(action: TAction, options?: TOptions) => DefinedQuery<TAction, TOptions>
+  const TPlaceholder extends unknown
+>(action: TAction, options?: QueryOptions<TAction, TPlaceholder>) => DefinedQuery<TAction, TPlaceholder>
 
 export type DefinedQuery<
   TAction extends QueryAction,
-  TOptions extends QueryOptions<TAction>
+  TPlaceholder extends unknown
 > = {
-  query: DefinedQueryFunction<TAction, TOptions>
-  useQuery: DefinedQueryComposition<TAction, TOptions>
+  query: DefinedQueryFunction<TAction, TPlaceholder>
+  useQuery: DefinedQueryComposition<TAction, TPlaceholder>
 }
 
 export type QueryDataSetter<T = unknown> = (data: T) => T

--- a/src/types/mutation.ts
+++ b/src/types/mutation.ts
@@ -54,9 +54,9 @@ export type OnErrorContext<
 }
 
 export type MutationOptions<
-  TAction extends MutationAction,
-  TPlaceholder extends unknown,
-  TTags extends MutationTags,
+  TAction extends MutationAction = MutationAction,
+  TPlaceholder extends unknown = unknown,
+  TTags extends MutationTags<TAction> = MutationTags<TAction>,
 > = {
   placeholder?: TPlaceholder,
   tags?: TTags,

--- a/src/types/query.ts
+++ b/src/types/query.ts
@@ -1,6 +1,7 @@
 import { RetryOptions } from "@/utilities/retry";
 import { Getter, MaybeGetter } from "./getters";
 import { QueryTag, Unset } from "@/types/tags";
+import { DefaultValue } from "./utilities";
 
 export type QueryAction = (...args: any[]) => any
 
@@ -21,9 +22,10 @@ export type QueryTags<
 > = QueryTag<QueryData<TAction> | Unset>[] | ((value: QueryData<TAction>) => QueryTag<QueryData<TAction> | Unset>[])
 
 export type QueryOptions<
-  TAction extends QueryAction,
+  TAction extends QueryAction = QueryAction,
+  TPlaceholder extends unknown = unknown
 > = {
-  placeholder?: any,
+  placeholder?: TPlaceholder,
   interval?: number,
   onSuccess?: (value: QueryData<TAction>) => void,
   onError?: (error: unknown) => void,
@@ -33,9 +35,9 @@ export type QueryOptions<
 
 export type Query<
   TAction extends QueryAction,
-  TOptions extends QueryOptions<TAction>
+  TPlaceholder extends unknown
 > = PromiseLike<AwaitedQuery<TAction>> & {
-  data: QueryData<TAction> | TOptions['placeholder'],
+  data: QueryData<TAction> | DefaultValue<TPlaceholder, undefined>,
   error: unknown,
   errored: boolean,
   executed: boolean,

--- a/src/utilities/createDefinedMutationOptions.ts
+++ b/src/utilities/createDefinedMutationOptions.ts
@@ -1,0 +1,89 @@
+import { getAllTags } from "@/getAllTags";
+import { SetQueryData, RefreshQueryData } from "@/types/client";
+import { MutationOptions } from "@/types/mutation";
+import { QueryData } from "@/types/query";
+
+type CreateDefinedMutationOptions = {
+  options: MutationOptions | undefined,
+  definedOptions: MutationOptions | undefined,
+  setQueryData: SetQueryData
+  refreshQueryData: RefreshQueryData
+}
+
+export function createDefinedMutationOptions({ 
+  options,
+  definedOptions, 
+  setQueryData,
+  refreshQueryData
+}: CreateDefinedMutationOptions): MutationOptions {
+  const { 
+    setQueryDataBefore: definedSetQueryDataBefore, 
+    setQueryDataAfter: definedSetQueryDataAfter, 
+    onExecute: definedOnExecute, 
+    onSuccess: definedOnSuccess,
+    onError: definedOnError
+  } = definedOptions ?? {}
+
+  const { 
+    setQueryDataBefore, 
+    setQueryDataAfter, 
+    onExecute, 
+    onSuccess,
+    onError
+  } = options ?? {}
+
+  return {
+    placeholder: options?.placeholder ?? definedOptions?.placeholder,
+    retries: options?.retries ?? definedOptions?.retries,
+    refreshQueryData: options?.refreshQueryData ?? definedOptions?.refreshQueryData,
+    tags: (data) => {
+      const definedTags = getAllTags(definedOptions?.tags, data)
+      const tags = getAllTags(options?.tags, data)
+
+      return [...definedTags, ...tags]
+    },
+    onExecute: (context) => {
+      if(setQueryDataBefore) {
+        const tags = getAllTags(options?.tags, undefined)
+        const setter = (data: QueryData) => setQueryDataBefore(data, context)
+        
+        setQueryData(tags, setter)
+      }
+      
+      if(definedSetQueryDataBefore) {
+        const tags = getAllTags(definedOptions?.tags, undefined)
+        const setter = (data: QueryData) => definedSetQueryDataBefore(data, context)
+        
+        setQueryData(tags, setter)
+      }
+
+      onExecute?.(context)
+      definedOnExecute?.(context)
+    },
+    onSuccess: (context) => {
+      const shouldRefreshQueryData = options?.refreshQueryData ?? definedOptions?.refreshQueryData ?? true
+      const tags = getAllTags(options?.tags, context.data)
+      const definedTags = getAllTags(definedOptions?.tags, context.data)
+
+      if(shouldRefreshQueryData) {
+        refreshQueryData(tags)
+        refreshQueryData(definedTags)
+      }
+
+      if(setQueryDataAfter) {
+        setQueryData(tags, (queryData: QueryData): QueryData => setQueryDataAfter(queryData, context))
+      }
+
+      if(definedSetQueryDataAfter) {
+        setQueryData(definedTags, (queryData: QueryData): QueryData => definedSetQueryDataAfter(queryData, context))
+      }
+
+      onSuccess?.(context)
+      definedOnSuccess?.(context)
+    },
+    onError: (context) => {
+      onError?.(context)
+      definedOnError?.(context)
+    }
+  }
+}

--- a/src/utilities/createDefinedQueryOptions.ts
+++ b/src/utilities/createDefinedQueryOptions.ts
@@ -1,0 +1,29 @@
+import { getAllTags } from "@/getAllTags"
+import { QueryOptions } from "@/types/query"
+
+type CreateDefinedQueryOptions = {
+  options: QueryOptions | undefined,
+  definedOptions: QueryOptions | undefined,
+}
+
+export function createDefinedQueryOptions({options, definedOptions}: CreateDefinedQueryOptions): QueryOptions {
+  return {
+    placeholder: options?.placeholder ?? definedOptions?.placeholder as any,
+    interval: options?.interval ?? definedOptions?.interval,
+    retries: options?.retries ?? definedOptions?.retries,
+    tags: (data) => {
+      const definedTags = getAllTags(definedOptions?.tags, data)
+      const tags = getAllTags(options?.tags, data)
+
+      return [...definedTags, ...tags]
+    },
+    onSuccess: (context) => {
+      options?.onSuccess?.(context)
+      definedOptions?.onSuccess?.(context)
+    },
+    onError: (context) => {
+      options?.onError?.(context)
+      definedOptions?.onError?.(context)
+    },
+  }
+}

--- a/src/utilities/createDefinedQueryOptions.ts
+++ b/src/utilities/createDefinedQueryOptions.ts
@@ -8,7 +8,7 @@ type CreateDefinedQueryOptions = {
 
 export function createDefinedQueryOptions({options, definedOptions}: CreateDefinedQueryOptions): QueryOptions {
   return {
-    placeholder: options?.placeholder ?? definedOptions?.placeholder as any,
+    placeholder: options?.placeholder ?? definedOptions?.placeholder,
     interval: options?.interval ?? definedOptions?.interval,
     retries: options?.retries ?? definedOptions?.retries,
     tags: (data) => {

--- a/src/utilities/createMutationOptions.ts
+++ b/src/utilities/createMutationOptions.ts
@@ -1,0 +1,46 @@
+import { getAllTags } from "@/getAllTags"
+import { SetQueryData } from "@/types/client"
+import { RefreshQueryData } from "@/types/client"
+import { MutationOptions } from "@/types/mutation"
+import { QueryData } from "@/types/query"
+
+type CreateMutationOptions = {
+  options: MutationOptions | undefined,
+  setQueryData: SetQueryData
+  refreshQueryData: RefreshQueryData
+}
+
+export function createMutationOptions({ options, setQueryData, refreshQueryData }: CreateMutationOptions): MutationOptions {
+  const { 
+    setQueryDataBefore,
+    setQueryDataAfter,
+    onExecute, 
+    onSuccess 
+  } = options ?? {}
+  
+  return {
+    ...options,
+    onExecute: (context) => {
+      if(setQueryDataBefore) {
+        const tags = getAllTags(options?.tags, undefined)
+
+        setQueryData(tags, (queryData: QueryData): QueryData => setQueryDataBefore(queryData, context))
+      }
+
+      onExecute?.(context)
+    },
+    onSuccess: (context) => {
+      const tags = getAllTags(options?.tags, context.data)
+
+      if(options?.refreshQueryData ?? true) {
+        refreshQueryData(tags)
+      }
+
+      if(setQueryDataAfter) {
+        setQueryData(tags, (queryData: QueryData): QueryData => setQueryDataAfter(queryData, context))
+      }
+
+      onSuccess?.(context)
+    },
+  }
+}


### PR DESCRIPTION
# Description
After working on `defineMutation` I realized that the types for query data was untested. Because of how query options and placeholders were types the data types were not correct. 

I added tests for placeholder and then fixed the types by making placeholder its own generic like I did for mutations which fixed the primary issue. 

Then the query utilities had the same type issues within their implementation that mutations had. Where the data type didn't match exactly (even though they evaluated to the same types). I fixed both the query and mutation type issues by creating new utilities that were responsible for the client/query and client/mutation integration as well as the implementation of defined options (which `defineQuery` didn't even support yet). 