### PR TITLE
remove deprecated lodash.isequal in favor of fast-deep-equal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,18 @@
 {
   "name": "@kitbag/query",
-  "version": "0.0.0",
+  "version": "0.0.1-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kitbag/query",
-      "version": "0.0.0",
+      "version": "0.0.1-beta.1",
       "dependencies": {
-        "lodash.isequal": "^4.5.0",
+        "fast-deep-equal": "^3.1.3",
         "vue": "^3.4.21"
       },
       "devDependencies": {
         "@kitbag/eslint-config": "^1.0.2",
-        "@types/lodash.isequal": "^4.5.8",
         "@vitejs/plugin-vue": "^5.2.1",
         "@vue/test-utils": "^2.4.6",
         "eslint": "^9.28.0",
@@ -1327,21 +1326,6 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/lodash": {
-      "version": "4.17.0",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.0.tgz",
-      "integrity": "sha512-t7dhREVv6dbNj0q17X12j7yDG4bD/DHYX7o5/DbDxobP0HnGPgpRz2Ej77aL7TZT3DSw13fqUTj8J4mMnqa7WA==",
-      "dev": true
-    },
-    "node_modules/@types/lodash.isequal": {
-      "version": "4.5.8",
-      "resolved": "https://registry.npmjs.org/@types/lodash.isequal/-/lodash.isequal-4.5.8.tgz",
-      "integrity": "sha512-uput6pg4E/tj2LGxCZo9+y27JNyB2OZuuI/T5F+ylVDYuqICLG2/ktjxx0v6GvVntAf8TvEzeQLcV0ffRirXuA==",
-      "dev": true,
-      "dependencies": {
-        "@types/lodash": "*"
-      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.33.0",
@@ -2734,7 +2718,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -3321,11 +3304,6 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/lodash.isequal": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@kitbag/query",
-  "version": "0.0.1-beta.1",
+  "private": false,
+  "version": "0.0.1-beta.2",
   "type": "module",
   "scripts": {
     "build": "vite build",
@@ -8,6 +9,29 @@
     "types": "tsc --noEmit",
     "lint": "eslint ./src",
     "lint:fix": "eslint ./src --fix"
+  },
+  "keywords": [
+    "typescript",
+    "query",
+    "vue",
+    "types",
+    "typed"
+  ],
+  "bugs": {
+    "url": "https://github.com/kitbagjs/query/issues"
+  },
+  "homepage": "https://github.com/kitbagjs/query#readme",
+  "files": [
+    "dist"
+  ],
+  "main": "./dist/kitbag-query.umd.cjs",
+  "module": "./dist/kitbag-query.js",
+  "types": "./dist/kitbag-query.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/kitbag-query.js",
+      "require": "./dist/kitbag-query.umd.cjs"
+    }
   },
   "dependencies": {
     "fast-deep-equal": "^3.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kitbag/query",
-  "version": "0.0.0",
+  "version": "0.0.1-beta.1",
   "type": "module",
   "scripts": {
     "build": "vite build",
@@ -10,12 +10,11 @@
     "lint:fix": "eslint ./src --fix"
   },
   "dependencies": {
-    "lodash.isequal": "^4.5.0",
+    "fast-deep-equal": "^3.1.3",
     "vue": "^3.4.21"
   },
   "devDependencies": {
     "@kitbag/eslint-config": "^1.0.2",
-    "@types/lodash.isequal": "^4.5.8",
     "@vitejs/plugin-vue": "^5.2.1",
     "@vue/test-utils": "^2.4.6",
     "eslint": "^9.28.0",

--- a/src/createUseQuery.ts
+++ b/src/createUseQuery.ts
@@ -1,7 +1,7 @@
 import { CreateQuery } from './createQueryGroups'
 import { Query, QueryAction, QueryActionArgs } from './types/query'
 import { onScopeDispose, ref, toRef, toRefs, toValue, watch } from 'vue'
-import isEqual from 'lodash.isequal'
+import equal from "fast-deep-equal"
 import { isDefined } from './utilities'
 import { UseQueryOptions } from './types/client'
 
@@ -22,7 +22,7 @@ export function createUseQuery(createQuery: CreateQuery, action: QueryAction, pa
   }
 
   watch(() => ({ enabled: enabled.value, parameters: toValue(parameters) }) as const, ({ enabled, parameters }, previous) => {
-    const isSameParameters = previous && isDefined(previous.parameters) && isEqual(previous.parameters, parameters)
+    const isSameParameters = previous && isDefined(previous.parameters) && equal(previous.parameters, parameters)
     const isSameEnabled = previous && previous.enabled === enabled
 
     if (isSameParameters && isSameEnabled) {


### PR DESCRIPTION
ran into this error message when I tried installing @kitbag/query from npm
<img width="1022" alt="image" src="https://github.com/user-attachments/assets/e8cd1a5b-7e7b-4442-a6b0-e55a5f8bc606" />

I ignored the suggestion to use node, since our package runs in the browser? Claude suggested [fast-deep-equal](https://www.npmjs.com/package/fast-deep-equal), which has 64M weekly downloads and is tiny 🤷 