### PR TITLE
QueryComposition arguments should ALWAYS be a getter

### DIFF
--- a/src/createQueryClient.spec-d.ts
+++ b/src/createQueryClient.spec-d.ts
@@ -53,16 +53,16 @@ describe('useQuery', () => {
       const placeholder = 'placeholder' as const
       const action = () => response
 
-      const queryA = useQuery(action, [])
+      const queryA = useQuery(action, () => [])
       expectTypeOf(queryA.data).toEqualTypeOf<typeof response | undefined>()
 
-      const queryB = useQuery(action, [], { placeholder })
+      const queryB = useQuery(action, () => [], { placeholder })
       expectTypeOf(queryB.data).toEqualTypeOf<typeof response | typeof placeholder>()
 
-      const queryC = await useQuery(action, [])
+      const queryC = await useQuery(action, () => [])
       expectTypeOf(queryC.data).toEqualTypeOf<typeof response>()
 
-      const queryD = await useQuery(action, [], { placeholder })
+      const queryD = await useQuery(action, () => [], { placeholder })
       expectTypeOf(queryD.data).toEqualTypeOf<typeof response>()
     })
   })

--- a/src/createQueryClient.spec.ts
+++ b/src/createQueryClient.spec.ts
@@ -269,7 +269,7 @@ describe('useQuery', () => {
     const action = vi.fn(() => response)
     const { useQuery } = createQueryClient()
 
-    const query = await useQuery(action, [])
+    const query = await useQuery(action, () => [])
 
     expect(query.data).toBe(response)
   })
@@ -280,7 +280,7 @@ describe('useQuery', () => {
       throw new Error('test')
     })
     const { useQuery } = createQueryClient()
-    const value = useQuery(action, [])
+    const value = useQuery(action, () => [])
 
     await expect(value).rejects.toThrow('test')
   })
@@ -339,8 +339,8 @@ describe('useQuery', () => {
     const action2 = vi.fn(() => false)
     const { useQuery } = createQueryClient()
 
-    const query1 = useQuery(action1, [])
-    const query2 = useQuery(action2, [])
+    const query1 = useQuery(action1, () => [])
+    const query2 = useQuery(action2, () => [])
 
     await vi.runOnlyPendingTimersAsync()
 
@@ -353,7 +353,7 @@ describe('useQuery', () => {
     const response = Symbol('response')
     const { useQuery } = createQueryClient()
 
-    const value = useQuery(() => response, [], { placeholder })
+    const value = useQuery(() => response, () => [], { placeholder })
 
     expect(value.data).toBe(placeholder)
 
@@ -368,7 +368,7 @@ describe('useQuery', () => {
       const action = vi.fn(() => response)
       const { useQuery } = createQueryClient()
 
-      const query = useQuery(action, [], { immediate: true })
+      const query = useQuery(action, () => [], { immediate: true })
 
       await vi.runOnlyPendingTimersAsync()
 
@@ -381,7 +381,7 @@ describe('useQuery', () => {
       const action = vi.fn(() => response)
       const { useQuery } = createQueryClient()
 
-      const query = useQuery(action, [], { immediate: false })
+      const query = useQuery(action, () => [], { immediate: false })
 
       await vi.runOnlyPendingTimersAsync()
 
@@ -395,7 +395,7 @@ describe('useQuery', () => {
       const action = vi.fn(() => response)
       const { useQuery } = createQueryClient()
 
-      const query = useQuery(action, [], { immediate: false, placeholder })
+      const query = useQuery(action, () => [], { immediate: false, placeholder })
 
       await vi.runOnlyPendingTimersAsync()
 
@@ -408,7 +408,7 @@ describe('useQuery', () => {
       const action = vi.fn(() => response)
       const { useQuery } = createQueryClient()
 
-      const query = useQuery(action, [], { immediate: false })
+      const query = useQuery(action, () => [], { immediate: false })
 
       await vi.runOnlyPendingTimersAsync()
 
@@ -426,7 +426,7 @@ describe('useQuery', () => {
       const action = vi.fn(() => response)
       const { useQuery } = createQueryClient()
 
-      const query = useQuery(action, [], { immediate: false })
+      const query = useQuery(action, () => [], { immediate: false })
 
       await vi.runOnlyPendingTimersAsync()
 
@@ -448,7 +448,7 @@ describe('useQuery', () => {
       })
       const { useQuery } = createQueryClient()
 
-      const query = useQuery(action, [], { immediate: false })
+      const query = useQuery(action, () => [], { immediate: false })
 
       await vi.runOnlyPendingTimersAsync()
 
@@ -489,7 +489,7 @@ describe('defineQuery', () => {
 
     const { useQuery } = defineQuery(action)
 
-    const value = useQuery([])
+    const value = useQuery(() => [])
 
     await vi.runOnlyPendingTimersAsync()
 

--- a/src/tag.spec-d.ts
+++ b/src/tag.spec-d.ts
@@ -6,33 +6,33 @@ import { tag } from './tag'
 test('tag function returns a tag when no callback is provided', () => {
   const value = tag()
 
-  expectTypeOf(value).toMatchTypeOf<QueryTag>()
+  expectTypeOf(value).toExtend<QueryTag>()
 })
 
 test('tag function returns a tag factory when a callback is provided', () => {
   const factory = tag((string: string) => string)
 
-  expectTypeOf(factory).toMatchTypeOf<QueryTagFactory<unknown, string>>()
+  expectTypeOf(factory).toExtend<QueryTagFactory<unknown, string>>()
 
   const value = factory('foo')
 
-  expectTypeOf(value).toMatchTypeOf<QueryTag<Unset>>()
+  expectTypeOf(value).toExtend<QueryTag<Unset>>()
 })
 
 test('tag function returns a typed tag when data generic is provided', () => {
   const value = tag<string>()
 
-  expectTypeOf(value).toMatchTypeOf<QueryTag<string>>()
+  expectTypeOf(value).toExtend<QueryTag<string>>()
 })
 
 test('tag factory returns a typed tag when data generic is provided', () => {
   const factory = tag<string, string>((value: string) => value)
 
-  expectTypeOf(factory).toMatchTypeOf<QueryTagFactory<string, string>>()
+  expectTypeOf(factory).toExtend<QueryTagFactory<string, string>>()
 
   const value = factory('foo')
 
-  expectTypeOf(value).toMatchTypeOf<QueryTag<string>>()
+  expectTypeOf(value).toExtend<QueryTag<string>>()
 })
 
 test('query from query function with tags callback is called with the query data', () => {
@@ -41,7 +41,7 @@ test('query from query function with tags callback is called with the query data
 
   query(action, [], {
     tags: (data) => {
-      expectTypeOf(data).toMatchTypeOf<string>()
+      expectTypeOf(data).toExtend<string>()
 
       return []
     },
@@ -52,9 +52,9 @@ test('query from query composition with tags callback is called with the query d
   const { useQuery } = createQueryClient()
   const action = vi.fn(() => 'foo')
 
-  useQuery(action, [], {
+  useQuery(action, () => [], {
     tags: (data) => {
-      expectTypeOf(data).toMatchTypeOf<string>()
+      expectTypeOf(data).toExtend<string>()
 
       return []
     },

--- a/src/types/getters.ts
+++ b/src/types/getters.ts
@@ -1,2 +1,1 @@
-export type MaybeGetter<T> = T | Getter<T>
 export type Getter<T> = () => T

--- a/src/types/query.ts
+++ b/src/types/query.ts
@@ -1,5 +1,5 @@
 import { RetryOptions } from '@/utilities/retry'
-import { Getter, MaybeGetter } from './getters'
+import { Getter } from './getters'
 import { QueryTag, Unset } from '@/types/tags'
 import { DefaultValue } from './utilities'
 
@@ -15,7 +15,7 @@ export type QueryData<
 
 export type QueryActionArgs<
   TAction extends QueryAction
-> = MaybeGetter<Parameters<TAction>> | Getter<Parameters<TAction> | null> | Getter<null>
+> = Getter<Parameters<TAction> | null> | Getter<null>
 
 export type QueryTags<
   TAction extends QueryAction = QueryAction


### PR DESCRIPTION
Consider the following example of `useQuery` in a Vue application

```ts
import { useQuery } from '@kitbag/query'

const { userId } = defineProps<{ userId: number }>()

const userQuery = useQuery(fetchUser, [userId])
```

It _feels_ like this is right, but in this example the query is **not** reactive. If `userId` changes, the query won't know to execute `fetchUser` again with the updated argument. The solution of course is to use a getter for your arguments, but to avoid confusion we have decided instead to just always ask for a getter to supply the `useQuery` arguments